### PR TITLE
Update blade height maximum limit in device configuration

### DIFF
--- a/pymammotion/data/model/device_config.py
+++ b/pymammotion/data/model/device_config.py
@@ -8,7 +8,7 @@ from pymammotion.utility.device_type import DeviceType
 @dataclass
 class DeviceLimits(DataClassORJSONMixin):
     blade_height_min: int = 30
-    blade_height_max: int = 70
+    blade_height_max: int = 100
     working_speed_min: float = 0.2
     working_speed_max: float = 1.2
     working_path_min: int = 15


### PR DESCRIPTION
### **User description**
Tried modifying the limits locally in home assistant integration but it seems to override with these limits.

(Same goes for mowing/working speed). Luba does "mow" at 1.2m/s though 😂


___

### **Description**
- Enhanced the `blade_height_max` limit to allow for greater flexibility in device operation.
- No other limits were modified in this update.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>device_config.py</strong><dd><code>Update device configuration limits for blade height</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pymammotion/data/model/device_config.py
<li>Increased <code>blade_height_max</code> limit from 70 to 100.<br> <li> No changes to other limits.<br>


</details>


  </td>
  <td><a href="https://github.com/mikey0000/PyMammotion/pull/61/files#diff-19cf388492198d3aac6902ba7a50f22e9371e173459ae4408fb7e156cda1803c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>