### PR TITLE
Fix keyword inconsistency for knife height parameter

### DIFF
--- a/pymammotion/mammotion/commands/messages/driver.py
+++ b/pymammotion/mammotion/commands/messages/driver.py
@@ -27,7 +27,7 @@ class MessageDriver(AbstractMessage, ABC):
 
     def set_blade_height(self, height: int):
         logger.debug(f"Send knife height height={height}")
-        build = mctrl_driver.MctlDriver(todev_knife_height_set=mctrl_driver.DrvKnifeHeight(knifeHeight=height))
+        build = mctrl_driver.MctlDriver(todev_knife_height_set=mctrl_driver.DrvKnifeHeight(knife_height=height))
         logger.debug(f"Send command--Knife motor height setting height={height}")
         return self.send_order_msg_driver(build)
 


### PR DESCRIPTION
### **User description**
looks like the wrong keyword for knifeHeight vs. knife_height


___

### **Description**
- Fixed the keyword inconsistency by changing `knifeHeight` to `knife_height` in the `set_blade_height` method.
- This change improves code readability and maintains consistency in parameter naming.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>driver.py</strong><dd><code>Fix keyword inconsistency for knife height parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pymammotion/mammotion/commands/messages/driver.py
<li>Corrected the keyword from <code>knifeHeight</code> to <code>knife_height</code>.<br> <li> Ensured consistency in the parameter naming for better readability.<br>


</details>


  </td>
  <td><a href="https://github.com/mikey0000/PyMammotion/pull/62/files#diff-99b908772e32d9318613c6e8c1e940e6e4d0b49f9d700b4f5ce75d10e7680724">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>