### PR TITLE
Fix coroutine warning in remove_device method

### DIFF
--- a/pymammotion/mammotion/devices/mammotion.py
+++ b/pymammotion/mammotion/devices/mammotion.py
@@ -248,7 +248,7 @@ class Mammotion:
         return cloud_client
 
     def remove_device(self, name: str) -> None:
-        self.devices.remove_device(name)
+        await self.devices.remove_device(name)
 
     def get_device_by_name(self, name: str) -> MammotionMixedDeviceManager:
         return self.devices.get_device(name)


### PR DESCRIPTION
### **User description**
Got the following error when "Reloading" in HA 
 
 /usr/local/lib/python3.12/site-packages/pymammotion/mammotion/devices/mammotion.py:251: RuntimeWarning: coroutine 'MammotionDevices.remove_device' was never awaited self.devices.remove_device(name)


___

### **Description**
- Fixed a RuntimeWarning by making the `remove_device` method asynchronous.
- Ensured that the `remove_device` function is awaited to prevent coroutine warnings.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mammotion.py</strong><dd><code>Fix coroutine warning by awaiting remove_device</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pymammotion/mammotion/devices/mammotion.py
<li>Changed <code>remove_device</code> method to be asynchronous.<br> <li> Added <code>await</code> keyword to the <code>remove_device</code> call.<br>


</details>


  </td>
  <td><a href="https://github.com/mikey0000/PyMammotion/pull/63/files#diff-f3a4101c93fa917c8cb89239303a8c8653d2f5a686a28a4028404cc686cb4c8c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>