### PR TITLE
fix(ble): use BleakClient to prevent stale GATT handle errors after reconnect

### DIFF
--- a/pymammotion/transport/ble.py
+++ b/pymammotion/transport/ble.py
@@ -8,7 +8,8 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from bleak.exc import BleakError
-from bleak_retry_connector import BleakClientWithServiceCache, establish_connection
+from bleak import BleakClient
+from bleak_retry_connector import establish_connection
 
 from pymammotion.bluetooth.const import UUID_NOTIFICATION_CHARACTERISTIC
 from pymammotion.transport.base import (
@@ -66,7 +67,7 @@ class BLETransport(Transport):
         super().__init__()
         self._config = config
         self._ble_device: BLEDevice | None = None
-        self._client: BleakClientWithServiceCache | None = None
+        self._client: BleakClient | None = None
         self._message: BleMessage | None = None
         self._availability: TransportAvailability = TransportAvailability.DISCONNECTED
         self._disconnect_on_idle: bool = True
@@ -128,7 +129,7 @@ class BLETransport(Transport):
 
         try:
             self._client = await establish_connection(
-                BleakClientWithServiceCache,
+                BleakClient,
                 self._ble_device,
                 self._config.device_id,
                 self._handle_disconnect,


### PR DESCRIPTION
## Problem

After a BLE disconnect (e.g. mower sleeping in dock), the mower's BLE stack
resets its GATT handle table on the next connection. `BleakClientWithServiceCache`
caches GATT service handles by BLE address and reuses them across reconnects.
This causes repeated errors on reconnect:

    BluetoothGATTAPIError: Bluetooth GATT Error handle=19 error=1 description=Invalid handle

The cache survives integration reloads because it lives in the BLEDevice objects
owned by the ESPHome integration, not the Mammotion integration. The only
recovery was a full HA restart.

## Fix

Replace `BleakClientWithServiceCache` with `BleakClient` so GATT services are
re-discovered on every connection, eliminating stale handle errors.

The performance cost (re-enumerating GATT on each connect) is negligible in
practice — BLE is secondary to MQTT for most users, and connects are infrequent.