### PR TITLE
Add VIRTUAL_WALL / CORRIDOR_LINE / CORRIDOR_POINT path types

### DIFF
--- a/pymammotion/data/model/hash_list.py
+++ b/pymammotion/data/model/hash_list.py
@@ -35,18 +35,27 @@ class PathType(IntEnum):
     SVG = 13
     """Pre-rendered SVG map tile."""
 
-    VISUAL_SAFETY_ZONE = 25
-    """Vision-detected safety zone (Luba 2 Vision / Pro only)."""
-
-    VISUAL_OBSTACLE_ZONE = 26
-    """Vision-detected obstacle zone (Luba 2 Vision / Pro only)."""
-
     DYNAMICS_LINE = 18
     """Live mow-progress path for the current session.
 
     Frameless w.r.t. hash keys; stored flat in ``HashList.dynamics_line``.
     Fetched via ``CommonDataSaga`` with ``action=8, type=18``.
     """
+
+    CORRIDOR_LINE = 19
+    """Corridor line between mowing zones (MN231)."""
+
+    CORRIDOR_POINT = 20
+    """Corridor waypoint between mowing zones (MN231)."""
+
+    VIRTUAL_WALL = 21
+    """User-drawn virtual fence / keep-out line."""
+
+    VISUAL_SAFETY_ZONE = 25
+    """Vision-detected safety zone (Luba 2 Vision / Pro only)."""
+
+    VISUAL_OBSTACLE_ZONE = 26
+    """Vision-detected obstacle zone (Luba 2 Vision / Pro only)."""
 
 
 @dataclass
@@ -296,6 +305,9 @@ class HashList(DataClassORJSONMixin):
     )  # type 10, sub cmd 3 — breakpoint line data, keyed by ub_path_hash
     visual_safety_zone: dict[int, FrameList] = field(default_factory=dict)  # type 25
     visual_obstacle_zone: dict[int, FrameList] = field(default_factory=dict)  # type 26
+    corridor_line: dict[int, FrameList] = field(default_factory=dict)  # type 19
+    corridor_point: dict[int, FrameList] = field(default_factory=dict)  # type 20
+    virtual_wall: dict[int, FrameList] = field(default_factory=dict)  # type 21
     plan: dict[str, Plan] = field(default_factory=dict)
     area_name: list[AreaHashNameList] = field(default_factory=list)
     current_mow_path: dict[int, dict[int, MowPath]] = field(default_factory=dict)
@@ -332,6 +344,13 @@ class HashList(DataClassORJSONMixin):
         self.visual_obstacle_zone = {
             hash_id: frames for hash_id, frames in self.visual_obstacle_zone.items() if hash_id in hashlist
         }
+        self.corridor_line = {
+            hash_id: frames for hash_id, frames in self.corridor_line.items() if hash_id in hashlist
+        }
+        self.corridor_point = {
+            hash_id: frames for hash_id, frames in self.corridor_point.items() if hash_id in hashlist
+        }
+        self.virtual_wall = {hash_id: frames for hash_id, frames in self.virtual_wall.items() if hash_id in hashlist}
 
         area_hashes = list(self.area.keys())
         for hash_id, plan_task in self.plan.copy().items():
@@ -380,6 +399,9 @@ class HashList(DataClassORJSONMixin):
             self.svg.keys(),
             self.visual_safety_zone.keys(),
             self.visual_obstacle_zone.keys(),
+            self.corridor_line.keys(),
+            self.corridor_point.keys(),
+            self.virtual_wall.keys(),
         )
         if sub_cmd == 3:
             all_hash_ids = set(self.line.keys())
@@ -480,6 +502,9 @@ class HashList(DataClassORJSONMixin):
             PathType.SVG: self.svg,
             PathType.VISUAL_SAFETY_ZONE: self.visual_safety_zone,
             PathType.VISUAL_OBSTACLE_ZONE: self.visual_obstacle_zone,
+            PathType.CORRIDOR_LINE: self.corridor_line,
+            PathType.CORRIDOR_POINT: self.corridor_point,
+            PathType.VIRTUAL_WALL: self.virtual_wall,
         }
 
     def update(self, hash_data: NavGetCommData | SvgMessage) -> bool:

--- a/tests/test_map_saga.py
+++ b/tests/test_map_saga.py
@@ -242,3 +242,62 @@ async def test_saga_stores_known_and_skips_unknown_types() -> None:
     assert area_hash in saga.result.area
     assert unknown_hash in saga.result.visual_obstacle_zone
     assert saga._command_builder.synchronize_hash_data.call_count == 2  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# test 4 — virtual wall (21) + corridor line (19) + corridor point (20) are stored
+# ---------------------------------------------------------------------------
+
+
+async def test_saga_stores_virtual_wall_and_corridor_types() -> None:
+    """Regression test for types 19, 20, 21.
+
+    Before these types were added to ``PathType`` / ``HashList``,
+    ``HashList.update`` returned False for them so each frame was dropped and
+    the saga looped re-requesting the same hash.  After the fix each type
+    lands in its dedicated dict and the saga completes.
+    """
+    broker = DeviceMessageBroker()
+    sends: list[bytes] = []
+
+    async def send_command(cmd: bytes) -> None:
+        sends.append(cmd)
+
+    _map = HashList()
+    saga = MapFetchSaga(
+        device_id="dev-4",
+        device_name="Luba-Test",
+        is_luba1=True,
+        command_builder=_make_command_builder(),
+        send_command=send_command,
+        get_map=lambda: _map,
+    )
+
+    corridor_line_hash = 3000000000000000001
+    corridor_point_hash = 3000000000000000002
+    virtual_wall_hash = 3000000000000000003
+
+    await asyncio.wait_for(
+        _run_saga_with_messages(
+            broker,
+            saga,
+            messages=[
+                _hash_list_msg([corridor_line_hash, corridor_point_hash, virtual_wall_hash]),
+                _comm_data_msg(corridor_line_hash, type_code=19),   # CORRIDOR_LINE
+                _comm_data_msg(corridor_point_hash, type_code=20),  # CORRIDOR_POINT
+                _comm_data_msg(virtual_wall_hash, type_code=21),    # VIRTUAL_WALL
+            ],
+            map_update=_map,
+        ),
+        timeout=5.0,
+    )
+
+    assert saga.result is not None
+    assert corridor_line_hash in saga.result.corridor_line
+    assert corridor_point_hash in saga.result.corridor_point
+    assert virtual_wall_hash in saga.result.virtual_wall
+    # Each type must be routed to exactly its own dict — not to a sibling.
+    assert corridor_line_hash not in saga.result.virtual_wall
+    assert virtual_wall_hash not in saga.result.corridor_line
+    # Saga should have asked for each hash exactly once.
+    assert saga._command_builder.synchronize_hash_data.call_count == 3  # noqa: SLF001


### PR DESCRIPTION
## Problem

I'm adding a map image entity in my fork of Mammotion-HA
(https://github.com/nickknissen/Mammotion-HA) and noticed that virtual
fences visible in the Android app never reach the integration. 

- Frames of `type = 19` (corridor line), `20` (corridor point), and
  `21` (virtual wall) are broadcast by the device alongside the types
  we already handle.
- `HashList.update()` dispatches via `_get_path_type_mapping()`, which
  only knows about types 0, 1, 2, 10, 12, 13, 25, 26 — so any
  19/20/21 frame returns `target_dict = None` and is silently dropped.
- Result: downstream consumers (the HA integration, the GeoJSON
  generator, anything building on `HashList`) never see user-drawn
  virtual fences or the MN231 corridor geometry that the Android app
  happily renders.

Cross-checked the type numbers against the decompiled Mammotion app
(`BaseMapFragment.java` dispatches these three to
`setCorridorLineDate` / `setCorridorPointDate` / `virtualWallLineLayer`
respectively), so they're the right slots.

## Solution

- Add `CORRIDOR_LINE = 19`, `CORRIDOR_POINT = 20`, `VIRTUAL_WALL = 21`
  to `PathType`.
- Add matching `corridor_line`, `corridor_point`, `virtual_wall` dicts
  on `HashList`.
- Wire them into `update_hash_lists` (pruning), `missing_hashlist`
  (manifest reconciliation), and `_get_path_type_mapping` (dispatch).

Same pattern as the earlier `VISUAL_SAFETY_ZONE` / `VISUAL_OBSTACLE_ZONE`
addition — no behaviour change for existing types.

## Verification

- New regression test `test_saga_stores_virtual_wall_and_corridor_types`
  in `tests/test_map_saga.py` asserts each of the three types lands in
  its own dict and that `MapFetchSaga` doesn't loop re-requesting them.
  Mirrors the shape of the existing `test_saga_does_not_loop_on_unknown_type`
  regression for type 26.
- All 4 tests in `test_map_saga.py` pass locally. No other tests touch
  `PathType` dispatch.