### PR TITLE
Render all stored PathTypes in generate_geojson (follow-up to #128)

### DIFF
--- a/examples/render_geojson_map.py
+++ b/examples/render_geojson_map.py
@@ -1,0 +1,221 @@
+"""Render a generated GeoJSON map in a browser using Leaflet.
+
+Builds a single self-contained HTML file that loads ArcGIS World Imagery
+as the basemap (matching the Mammotion-HA wiki map page), inlines the
+GeoJSON so there is no CORS / local-server hassle, and pipes each
+feature's ``properties`` directly into ``L.geoJSON``'s ``style``
+callback so the Leaflet Path options that ``generate_geojson.py``
+emits (``color`` / ``fillColor`` / ``weight`` / ``dashArray`` / …)
+render exactly as the library intended.
+
+Usage
+-----
+    uv run python examples/render_geojson_map.py [GEOJSON] [-o OUTPUT] [--no-open]
+
+Arguments (all optional):
+    GEOJSON     Path to a GeoJSON FeatureCollection — defaults to the
+                most recently modified ``examples/dev_output/map_*.geojson``
+                (i.e. the last output of ``scripts/generate_live_map_geojson.py``).
+    -o OUTPUT   Where to write the HTML (default: next to the GeoJSON).
+    --no-open   Skip launching the browser — just write the file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import webbrowser
+from pathlib import Path
+
+# Matches how Home Assistant frontends reference the assets pack.
+# For the standalone viewer we rewrite to the raw GitHub URL so the
+# mower / dock / RTK icons actually load without the HA www mount.
+_HA_ICON_PREFIX = "/local/community/ha-mammotion-assets/"
+_GITHUB_ICON_PREFIX = "https://raw.githubusercontent.com/mikey0000/ha-mammotion-assets/main/"
+
+HTML_TEMPLATE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Mammotion map — {title}</title>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+        integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+        crossorigin="">
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+          integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+          crossorigin=""></script>
+  <style>
+    html, body {{ margin: 0; height: 100%; font-family: -apple-system, BlinkMacSystemFont, sans-serif; }}
+    #map {{ height: 100%; width: 100%; background: #222; }}
+    .info-panel {{
+      position: absolute; top: 10px; left: 10px; z-index: 1000;
+      background: rgba(255,255,255,0.92); padding: 8px 12px;
+      border-radius: 6px; box-shadow: 0 2px 6px rgba(0,0,0,.3);
+      max-width: 300px; font-size: 13px;
+    }}
+    .info-panel h3 {{ margin: 0 0 6px 0; font-size: 14px; }}
+    .info-panel .count {{ display: inline-block; margin: 0 8px 2px 0; }}
+    .leaflet-popup-content-wrapper {{ border-radius: 6px; }}
+    .leaflet-popup-content b {{ font-size: 13px; }}
+    .leaflet-popup-content small {{ color: #666; }}
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+  <div class="info-panel">
+    <h3>{title}</h3>
+    <div id="feature-counts"></div>
+    <div style="margin-top:6px;color:#666;font-size:12px;">
+      Click a feature for details. Basemap: Esri World Imagery.
+    </div>
+  </div>
+  <script>
+    const GEOJSON = {geojson_json};
+    const HA_ICON_PREFIX = {ha_prefix_json};
+    const GITHUB_ICON_PREFIX = {gh_prefix_json};
+
+    const map = L.map('map', {{ maxZoom: 24, zoomSnap: 0.25 }});
+
+    L.tileLayer(
+      'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{{z}}/{{y}}/{{x}}',
+      {{
+        maxZoom: 24,
+        minZoom: 14,
+        maxNativeZoom: 19,
+        attribution: 'Tiles &copy; Esri &mdash; Source: Esri, Maxar, Earthstar Geographics',
+      }},
+    ).addTo(map);
+
+    // Rewrite HA-local icon paths to the public asset repo so the viewer
+    // works outside HA.
+    function rewriteIconUrl(url) {{
+      if (!url) return url;
+      if (url.startsWith(HA_ICON_PREFIX)) {{
+        return GITHUB_ICON_PREFIX + url.slice(HA_ICON_PREFIX.length);
+      }}
+      return url;
+    }}
+
+    const counts = {{}};
+
+    const layer = L.geoJSON(GEOJSON, {{
+      // Pipe properties straight into L.Path.setStyle — this is the
+      // whole reason generate_geojson.py uses Leaflet key names.
+      style: (feature) => feature.properties || {{}},
+      pointToLayer: (feature, latlng) => {{
+        const p = feature.properties || {{}};
+        const iconUrl = rewriteIconUrl(p.iconUrl);
+        if (iconUrl) {{
+          return L.marker(latlng, {{
+            icon: L.icon({{
+              iconUrl: iconUrl,
+              iconSize: p.iconSize || [30, 30],
+              iconAnchor: p.iconAnchor || [15, 30],
+            }}),
+            title: p.Name || p.title || p.type_name || '',
+          }});
+        }}
+        return L.circleMarker(latlng, p);
+      }},
+      onEachFeature: (feature, layer) => {{
+        const p = feature.properties || {{}};
+        const type = p.type_name || 'unknown';
+        counts[type] = (counts[type] || 0) + 1;
+
+        const name = p.Name || p.title || type;
+        const desc = p.description || '';
+        const meta = [];
+        if (p.length) meta.push('length: ' + p.length.toFixed(1) + ' m');
+        if (p.area) meta.push('area: ' + p.area.toFixed(1) + ' m&sup2;');
+        const body =
+          '<b>' + name + '</b><br>' +
+          (desc ? desc + '<br>' : '') +
+          '<small>' + type + (meta.length ? ' — ' + meta.join(', ') : '') + '</small>';
+        layer.bindPopup(body);
+        layer.bindTooltip(name, {{ direction: 'top', sticky: true }});
+      }},
+    }}).addTo(map);
+
+    if (layer.getBounds().isValid()) {{
+      map.fitBounds(layer.getBounds(), {{ padding: [30, 30] }});
+    }} else {{
+      map.setView([0, 0], 2);
+    }}
+
+    // Fill in the info-panel counts now that onEachFeature has run for every feature.
+    const panel = document.getElementById('feature-counts');
+    panel.innerHTML = Object.keys(counts)
+      .sort()
+      .map((k) => '<span class="count"><b>' + counts[k] + '</b> ' + k + '</span>')
+      .join('');
+  </script>
+</body>
+</html>
+"""
+
+
+def _find_latest_geojson() -> Path | None:
+    """Return the most-recent ``map_*.geojson`` under ``examples/dev_output``."""
+    dev_output = Path(__file__).parent / "dev_output"
+    if not dev_output.exists():
+        return None
+    candidates = sorted(dev_output.glob("map_*.geojson"), key=lambda p: p.stat().st_mtime, reverse=True)
+    return candidates[0] if candidates else None
+
+
+def render(geojson_path: Path, output_path: Path) -> None:
+    """Build the HTML file with *geojson_path* inlined and write to *output_path*."""
+    with geojson_path.open(encoding="utf-8") as fh:
+        geo = json.load(fh)
+
+    feature_count = len(geo.get("features", []))
+    title = geojson_path.stem + f" ({feature_count} features)"
+
+    html = HTML_TEMPLATE.format(
+        title=title,
+        geojson_json=json.dumps(geo),
+        ha_prefix_json=json.dumps(_HA_ICON_PREFIX),
+        gh_prefix_json=json.dumps(_GITHUB_ICON_PREFIX),
+    )
+    output_path.write_text(html, encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
+    parser.add_argument(
+        "geojson",
+        nargs="?",
+        type=Path,
+        help="Path to a GeoJSON file (default: latest examples/dev_output/map_*.geojson)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=None,
+        help="Output HTML path (default: alongside the GeoJSON with .html suffix)",
+    )
+    parser.add_argument("--no-open", action="store_true", help="Do not launch a browser")
+    args = parser.parse_args()
+
+    geojson_path = args.geojson or _find_latest_geojson()
+    if geojson_path is None:
+        parser.error(
+            "No GeoJSON specified and none found in examples/dev_output/. "
+            "Run scripts/generate_live_map_geojson.py first or pass an explicit path."
+        )
+    if not geojson_path.exists():
+        parser.error(f"GeoJSON not found: {geojson_path}")
+
+    output_path = args.output or geojson_path.with_suffix(".html")
+    render(geojson_path, output_path)
+    print(f"Wrote {output_path}")
+
+    if not args.no_open:
+        webbrowser.open(output_path.resolve().as_uri())
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pymammotion/data/model/generate_geojson.py
+++ b/pymammotion/data/model/generate_geojson.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import math
-from typing import Any
+from typing import Any, ClassVar
 
 from shapely.geometry import Point
 
@@ -532,17 +532,30 @@ class GeojsonGenerator:
         }
 
         for type_name, map_objects in type_mapping.items():
-            for hash_key, frame_list in map_objects.items():
+            # Sort by hash so the per-type index is stable across runs — human-readable
+            # fallback names like "Virtual Wall 1" should not flip between invocations.
+            index = 0
+            for hash_key, frame_list in sorted(map_objects.items()):
                 if not GeojsonGenerator._validate_frame_list(frame_list, hash_key, area_names):
                     continue
 
+                index += 1
                 local_coords = GeojsonGenerator._collect_frame_coordinates(frame_list)
                 total_frames += len(frame_list.data)
 
                 lonlat_coords = GeojsonGenerator._convert_to_lonlat_coords(local_coords, rtk_location)
                 length, area = GeojsonGenerator.map_object_stats(local_coords)
 
-                feature = GeojsonGenerator._create_feature(hash_key, frame_list, type_name, lonlat_coords, length, area)
+                feature = GeojsonGenerator._create_feature(
+                    hash_key,
+                    frame_list,
+                    type_name,
+                    lonlat_coords,
+                    length,
+                    area,
+                    index=index,
+                    area_names=area_names,
+                )
                 if feature:
                     geo_json["features"].append(feature)
 
@@ -667,7 +680,14 @@ class GeojsonGenerator:
 
     @staticmethod
     def _create_feature(
-        hash_key: int, frame_list: FrameList, type_name: str, lonlat_coords: CoordinateList, length: float, area: float
+        hash_key: int,
+        frame_list: FrameList,
+        type_name: str,
+        lonlat_coords: CoordinateList,
+        length: float,
+        area: float,
+        index: int = 1,
+        area_names: dict[int, str] | None = None,
     ) -> GeoJSONFeature | None:
         """Create a GeoJSON feature from frame list data.
 
@@ -678,6 +698,12 @@ class GeojsonGenerator:
             lonlat_coords: List of [longitude, latitude] coordinate pairs
             length: Calculated length of the feature
             area: Calculated area of the feature
+            index: 1-based sequence number within *type_name* — used for
+                fallback names like "Virtual Wall 2" when the device has
+                not stored a user label for this type.
+            area_names: hash → name lookup built from ``HashList.area_name``.
+                Used to name area features and to qualify obstacles with
+                their parent zone.
 
         Returns:
             GeoJSON feature dictionary or None if invalid
@@ -685,12 +711,32 @@ class GeojsonGenerator:
         """
         first_frame = frame_list.data[0]
         type_id = first_frame.type
-        object_name = ""
+        user_label = ""
         if isinstance(first_frame, NavGetCommData):
-            object_name = first_frame.name_time.name
+            user_label = first_frame.name_time.name
+
+        object_name = GeojsonGenerator._build_feature_name(
+            type_name=type_name,
+            hash_key=hash_key,
+            index=index,
+            user_label=user_label,
+            area_names=area_names or {},
+        )
+        description = GeojsonGenerator._build_feature_description(
+            type_name=type_name,
+            first_frame=first_frame,
+            area_names=area_names or {},
+        )
 
         properties = GeojsonGenerator._create_feature_properties(
-            hash_key, type_id, type_name, first_frame, length, area, object_name
+            hash_key,
+            type_id,
+            type_name,
+            first_frame,
+            length,
+            area,
+            object_name,
+            description,
         )
         geometry = GeojsonGenerator._create_feature_geometry(type_id, lonlat_coords, properties)
 
@@ -698,6 +744,79 @@ class GeojsonGenerator:
             return None
 
         return {"type": "Feature", "properties": properties, "geometry": geometry}
+
+    # Human-readable title template per PathType.  ``{n}`` is the 1-based index
+    # within the type, used when the device has no user label for this hash.
+    _NAME_TEMPLATES: ClassVar[dict[str, str]] = {
+        "area": "Zone {n}",
+        "path": "Path {n}",
+        "obstacle": "Obstacle {n}",
+        "dump": "Dump zone {n}",
+        "corridor_line": "Corridor {n}",
+        "corridor_point": "Corridor waypoint {n}",
+        "virtual_wall": "Virtual wall {n}",
+        "visual_safety_zone": "Safety zone {n}",
+        "visual_obstacle_zone": "Obstacle zone {n}",
+    }
+
+    # Short description per PathType.  For obstacles we append " in <area>"
+    # when a parent hash is known.
+    _DESCRIPTION_TEMPLATES: ClassVar[dict[str, str]] = {
+        "area": "Mowing zone",
+        "path": "Planned path",
+        "obstacle": "Obstacle",
+        "dump": "Clippings dump zone",
+        "corridor_line": "Corridor line between zones (MN231)",
+        "corridor_point": "Corridor waypoint between zones (MN231)",
+        "virtual_wall": "User-drawn virtual fence",
+        "visual_safety_zone": "Vision-detected safety zone",
+        "visual_obstacle_zone": "Vision-detected obstacle zone",
+    }
+
+    @staticmethod
+    def _build_feature_name(
+        *,
+        type_name: str,
+        hash_key: int,
+        index: int,
+        user_label: str,
+        area_names: dict[int, str],
+    ) -> str:
+        """Return a non-empty display name for a feature.
+
+        Priority: user label from ``name_time`` → area-name lookup (covers
+        areas whose name is held in ``HashList.area_name`` rather than on the
+        frame itself) → synthesized "Type N" fallback.
+        """
+        if user_label:
+            return user_label
+        if type_name == "area":
+            looked_up = area_names.get(hash_key)
+            if looked_up:
+                return looked_up
+        template = GeojsonGenerator._NAME_TEMPLATES.get(type_name, "{type} {n}")
+        return template.format(n=index, type=type_name)
+
+    @staticmethod
+    def _build_feature_description(
+        *,
+        type_name: str,
+        first_frame: Any,
+        area_names: dict[int, str],
+    ) -> str:
+        """Return a short human-readable description for a feature.
+
+        For obstacles the parent area (via ``paternal_hash_a`` / ``_b``) is
+        appended when it maps to a known area name — this matches how the
+        APK tags obstacles "Obstacle in Front Lawn".
+        """
+        base = GeojsonGenerator._DESCRIPTION_TEMPLATES.get(type_name, type_name.replace("_", " "))
+        if type_name == "obstacle":
+            parent_hash = getattr(first_frame, "paternal_hash_a", 0) or getattr(first_frame, "paternal_hash_b", 0)
+            parent_name = area_names.get(parent_hash) if parent_hash else None
+            if parent_name:
+                return f"{base} in {parent_name}"
+        return base
 
     @staticmethod
     def _create_mow_path_feature(
@@ -732,18 +851,26 @@ class GeojsonGenerator:
 
     @staticmethod
     def _create_feature_properties(
-        hash_key: int, type_id: int, type_name: str, first_frame: Any, length: float, area: float, object_name: str = ""
+        hash_key: int,
+        type_id: int,
+        type_name: str,
+        first_frame: Any,
+        length: float,
+        area: float,
+        object_name: str = "",
+        description: str = "",
     ) -> dict[str, Any]:
         """Create properties dictionary for GeoJSON feature.
 
         Args:
             hash_key: Hash identifier
-            object_name: Name of the object
             type_id: Type ID of the feature
             type_name: Type name of the feature
             first_frame: First frame from the FrameList
             length: Calculated length
             area: Calculated area
+            object_name: Display name (from device or synthesized)
+            description: Human-readable description
 
         Returns:
             Properties dictionary
@@ -753,7 +880,7 @@ class GeojsonGenerator:
             "hash": hash_key,
             "title": object_name,
             "Name": object_name,
-            "description": "description <b>test</b>",
+            "description": description,
             "type_id": type_id,
             "type_name": type_name,
             "parent_hash_a": first_frame.paternal_hash_a,

--- a/pymammotion/data/model/generate_geojson.py
+++ b/pymammotion/data/model/generate_geojson.py
@@ -1,3 +1,35 @@
+"""Build styled GeoJSON ``FeatureCollection`` output from a ``HashList``.
+
+Styling convention
+------------------
+Every feature's ``properties`` dict carries **Leaflet Path options**
+(https://leafletjs.com/reference.html#path) so a frontend can pipe
+``feature.properties`` straight into ``L.Path.setStyle()`` / a
+``L.geoJSON(data, {style: f => f.properties})`` call.
+
+Supported keys (stroke + fill, Leaflet spelling):
+
+* ``color`` — stroke colour (string)
+* ``weight`` — stroke width in px
+* ``opacity`` — stroke opacity (0..1)
+* ``dashArray`` — dash pattern, e.g. ``"8, 6"``
+* ``lineCap`` / ``lineJoin`` — ``"round"`` etc.
+* ``fillColor`` — fill colour (polygon / ``CircleMarker``).  Leaflet's
+  ``fill`` key is a *boolean*, so fill colour **must** be ``fillColor``
+  — earlier versions of this module emitted ``fill: "<color>"`` which
+  Leaflet silently ignored, falling back to ``color`` for the fill.
+* ``fillOpacity`` — fill opacity (0..1)
+* ``radius`` — ``CircleMarker`` radius in px (station / point features)
+
+``simplestyle-spec`` (``stroke``, ``stroke-width``, ``fill``,
+``fill-opacity`` … — hyphenated) is **not** used.  Consumers that want
+that spec can map the keys themselves.
+
+Icon features (RTK, dock) additionally carry ``iconImage`` /
+``iconSize`` / ``iconAnchor`` / ``iconUrl`` — a Mapbox-GL-style symbol
+layer shape that the HA-Mammotion-Assets icon pack consumes.
+"""
+
 import json
 import logging
 import math
@@ -41,13 +73,27 @@ DOCK_IMAGE = {
 # STYLE CONFIGURATION
 #############################
 
-DOCK_STYLE = {"color": "lightgray", "fill": "lightgray", "weight": 2, "opacity": 1.0, "fillOpacity": 0.7, "radius": 10}
+DOCK_STYLE = {
+    "color": "lightgray",
+    "fillColor": "lightgray",
+    "weight": 2,
+    "opacity": 1.0,
+    "fillOpacity": 0.7,
+    "radius": 10,
+}
 
-RTK_STYLE = {"color": "purple", "fill": "purple", "weight": 2, "opacity": 1.0, "fillOpacity": 0.7, "radius": 7}
+RTK_STYLE = {
+    "color": "purple",
+    "fillColor": "purple",
+    "weight": 2,
+    "opacity": 1.0,
+    "fillOpacity": 0.7,
+    "radius": 7,
+}
 
 AREA_STYLE = {
     "color": "green",
-    "fill": "darkgreen",
+    "fillColor": "darkgreen",
     "weight": 3,
     "opacity": 0.8,
     "fillOpacity": 0.3,
@@ -58,7 +104,7 @@ AREA_STYLE = {
 
 OBSTACLE_STYLE = {
     "color": "#FF4D00",
-    "fill": "darkorange",
+    "fillColor": "darkorange",
     "weight": 2,
     "opacity": 0.9,
     "fillOpacity": 0.4,
@@ -71,15 +117,19 @@ PATH_STYLE = {
     "color": "#ffffff",
     "weight": 8,
     "opacity": 1.0,
-    "zIndex": -1,
     "dashArray": "",
     "lineCap": "round",
     "lineJoin": "round",
-    "road_center_color": "#696969",
-    "road_center_dash": "8, 8",
 }
 
-POINT_STYLE = {"color": "blue", "fill": "lightblue", "weight": 2, "opacity": 1.0, "fillOpacity": 0.7, "radius": 5}
+POINT_STYLE = {
+    "color": "blue",
+    "fillColor": "lightblue",
+    "weight": 2,
+    "opacity": 1.0,
+    "fillOpacity": 0.7,
+    "radius": 5,
+}
 
 DYNAMICS_LINE_STYLE = {
     "color": "#FFD700",  # gold — visually distinct from the planned green mow path
@@ -134,7 +184,7 @@ CORRIDOR_LINE_STYLE = {
 # PathType 20 — MN231 corridor waypoints. APK renders these as circular markers.
 CORRIDOR_POINT_STYLE = {
     "color": "#145FF2",
-    "fill": "#145FF2",
+    "fillColor": "#145FF2",
     "weight": 2,
     "opacity": 1.0,
     "fillOpacity": 0.8,
@@ -157,7 +207,7 @@ VIRTUAL_WALL_STYLE = {
 # APK: map_no_stop_zone #007aff with reduced fill alpha — safety buffer around obstacles.
 VISUAL_SAFETY_ZONE_STYLE = {
     "color": "#007AFF",
-    "fill": "#007AFF",
+    "fillColor": "#007AFF",
     "weight": 2,
     "opacity": 0.9,
     "fillOpacity": 0.3,
@@ -171,7 +221,7 @@ VISUAL_SAFETY_ZONE_STYLE = {
 # (vision-picked obstacles rendered in orange).
 VISUAL_OBSTACLE_ZONE_STYLE = {
     "color": "#CC7700",
-    "fill": "#CC7700",
+    "fillColor": "#CC7700",
     "weight": 2,
     "opacity": 0.9,
     "fillOpacity": 0.4,

--- a/pymammotion/data/model/generate_geojson.py
+++ b/pymammotion/data/model/generate_geojson.py
@@ -120,12 +120,77 @@ BORDER_PASS_STYLE = {
     "lineJoin": "round",
 }
 
+# PathType 19 — MN231 corridor line between zones.
+# APK: MapColorTag.Map_Color_Corridor_231 = #145FF2, lineWidth 14 at max zoom.
+CORRIDOR_LINE_STYLE = {
+    "color": "#145FF2",
+    "weight": 5,
+    "opacity": 0.9,
+    "dashArray": "",
+    "lineCap": "round",
+    "lineJoin": "round",
+}
+
+# PathType 20 — MN231 corridor waypoints. APK renders these as circular markers.
+CORRIDOR_POINT_STYLE = {
+    "color": "#145FF2",
+    "fill": "#145FF2",
+    "weight": 2,
+    "opacity": 1.0,
+    "fillOpacity": 0.8,
+    "radius": 5,
+}
+
+# PathType 21 — user-drawn virtual fence / keep-out line.
+# APK uses an image line-pattern (icon_virtual_machine_line) which doesn't
+# translate cleanly to GeoJSON; render as a red dashed line to signal "keep out".
+VIRTUAL_WALL_STYLE = {
+    "color": "#FF4D00",
+    "weight": 3,
+    "opacity": 0.95,
+    "dashArray": "8, 6",
+    "lineCap": "round",
+    "lineJoin": "round",
+}
+
+# PathType 25 — vision-detected safety zone (Luba 2 Vision / Pro).
+# APK: map_no_stop_zone #007aff with reduced fill alpha — safety buffer around obstacles.
+VISUAL_SAFETY_ZONE_STYLE = {
+    "color": "#007AFF",
+    "fill": "#007AFF",
+    "weight": 2,
+    "opacity": 0.9,
+    "fillOpacity": 0.3,
+    "dashArray": "",
+    "lineCap": "round",
+    "lineJoin": "round",
+}
+
+# PathType 26 — vision-detected obstacle zone (Luba 2 Vision / Pro).
+# Colour #CC7700 comes from the Android app's Map_Color_Fill_CC7700 tag
+# (vision-picked obstacles rendered in orange).
+VISUAL_OBSTACLE_ZONE_STYLE = {
+    "color": "#CC7700",
+    "fill": "#CC7700",
+    "weight": 2,
+    "opacity": 0.9,
+    "fillOpacity": 0.4,
+    "dashArray": "",
+    "lineCap": "round",
+    "lineJoin": "round",
+}
+
 geojson_metadata = {"name": "Lawn Areas", "description": "Generated from Mammotion diagnostics data"}
 
 # Map type IDs — these match PathType enum values from NavGetCommData.type
 TYPE_MOWING_ZONE: int = 0
 TYPE_OBSTACLE: int = 1
 TYPE_PATH: int = 2
+TYPE_CORRIDOR_LINE: int = 19
+TYPE_CORRIDOR_POINT: int = 20
+TYPE_VIRTUAL_WALL: int = 21
+TYPE_VISUAL_SAFETY_ZONE: int = 25
+TYPE_VISUAL_OBSTACLE_ZONE: int = 26
 
 # Coordinate conversion constants
 METERS_PER_DEGREE: int = 111320
@@ -449,12 +514,21 @@ class GeojsonGenerator:
         """
         total_frames = 0
 
-        # Map type names to their corresponding dictionaries in HashList
+        # Map type names to their corresponding dictionaries in HashList.
+        # Keys here are informational — the actual styling / geometry is
+        # selected in _create_feature_geometry via the per-frame ``type`` field
+        # (PathType).  Adding a dict here enables dispatch; omitting it silently
+        # drops the type from the GeoJSON output.
         type_mapping: dict[str, dict[int, FrameList]] = {
             "area": hash_list.area,
             "path": hash_list.path,
             "obstacle": hash_list.obstacle,
             "dump": hash_list.dump,
+            "corridor_line": hash_list.corridor_line,
+            "corridor_point": hash_list.corridor_point,
+            "virtual_wall": hash_list.virtual_wall,
+            "visual_safety_zone": hash_list.visual_safety_zone,
+            "visual_obstacle_zone": hash_list.visual_obstacle_zone,
         }
 
         for type_name, map_objects in type_mapping.items():
@@ -712,7 +786,26 @@ class GeojsonGenerator:
         if type_id == TYPE_PATH and len(lonlat_coords) > 1:
             properties.update(PATH_STYLE)
             return {"type": "LineString", "coordinates": lonlat_coords}
-        return None  # Point (ignore)
+        if type_id == TYPE_CORRIDOR_LINE and len(lonlat_coords) > 1:
+            properties.update(CORRIDOR_LINE_STYLE)
+            return {"type": "LineString", "coordinates": lonlat_coords}
+        if type_id == TYPE_CORRIDOR_POINT:
+            # Corridor waypoints — each coord is a separate marker in the APK.
+            # Emit a MultiPoint so every waypoint is rendered at its own location.
+            if not lonlat_coords:
+                return None
+            properties.update(CORRIDOR_POINT_STYLE)
+            return {"type": "MultiPoint", "coordinates": lonlat_coords}
+        if type_id == TYPE_VIRTUAL_WALL and len(lonlat_coords) > 1:
+            properties.update(VIRTUAL_WALL_STYLE)
+            return {"type": "LineString", "coordinates": lonlat_coords}
+        if type_id == TYPE_VISUAL_SAFETY_ZONE:
+            properties.update(VISUAL_SAFETY_ZONE_STYLE)
+            return {"type": "Polygon", "coordinates": [lonlat_coords]}
+        if type_id == TYPE_VISUAL_OBSTACLE_ZONE:
+            properties.update(VISUAL_OBSTACLE_ZONE_STYLE)
+            return {"type": "Polygon", "coordinates": [lonlat_coords]}
+        return None  # Unknown type — drop.
 
     @staticmethod
     def _save_geojson(geoJSON: GeoJSONCollection) -> None:

--- a/pymammotion/data/model/generate_geojson.py
+++ b/pymammotion/data/model/generate_geojson.py
@@ -171,7 +171,8 @@ BORDER_PASS_STYLE = {
 }
 
 # PathType 19 — MN231 corridor line between zones.
-# APK: MapColorTag.Map_Color_Corridor_231 = #145FF2, lineWidth 14 at max zoom.
+# APK uses MapColorTag.Map_Color_Corridor_231 = #145FF2,
+# with lineWidth 14 at max zoom.
 CORRIDOR_LINE_STYLE = {
     "color": "#145FF2",
     "weight": 5,
@@ -192,8 +193,9 @@ CORRIDOR_POINT_STYLE = {
 }
 
 # PathType 21 — user-drawn virtual fence / keep-out line.
-# APK uses an image line-pattern (icon_virtual_machine_line) which doesn't
-# translate cleanly to GeoJSON; render as a red dashed line to signal "keep out".
+# The APK uses an image line-pattern (icon_virtual_machine_line),
+# which does not translate cleanly to GeoJSON.
+# Render it as a red dashed line to signal "keep out".
 VIRTUAL_WALL_STYLE = {
     "color": "#FF4D00",
     "weight": 3,
@@ -204,7 +206,8 @@ VIRTUAL_WALL_STYLE = {
 }
 
 # PathType 25 — vision-detected safety zone (Luba 2 Vision / Pro).
-# APK: map_no_stop_zone #007aff with reduced fill alpha — safety buffer around obstacles.
+# The APK uses map_no_stop_zone #007AFF with reduced fill alpha,
+# representing a safety buffer around obstacles.
 VISUAL_SAFETY_ZONE_STYLE = {
     "color": "#007AFF",
     "fillColor": "#007AFF",
@@ -217,8 +220,8 @@ VISUAL_SAFETY_ZONE_STYLE = {
 }
 
 # PathType 26 — vision-detected obstacle zone (Luba 2 Vision / Pro).
-# Colour #CC7700 comes from the Android app's Map_Color_Fill_CC7700 tag
-# (vision-picked obstacles rendered in orange).
+# The colour #CC7700 comes from the Android app's
+# Map_Color_Fill_CC7700 tag for vision-picked obstacles.
 VISUAL_OBSTACLE_ZONE_STYLE = {
     "color": "#CC7700",
     "fillColor": "#CC7700",
@@ -552,6 +555,12 @@ class GeojsonGenerator:
     ) -> int:
         """Process all map objects and add them to GeoJSON.
 
+        ``type_mapping`` is the dispatch table from logical map object names to
+        their corresponding ``HashList`` buckets. The keys are informational;
+        geometry and styling are chosen later from each frame's ``type`` field.
+        Adding a bucket here enables GeoJSON output for that ``PathType``, while
+        omitting one silently drops that object type from the generated output.
+
         Args:
             hash_list: HashList object containing map data
             rtk_location: Tuple of (longitude, latitude) for rtk position
@@ -564,11 +573,6 @@ class GeojsonGenerator:
         """
         total_frames = 0
 
-        # Map type names to their corresponding dictionaries in HashList.
-        # Keys here are informational — the actual styling / geometry is
-        # selected in _create_feature_geometry via the per-frame ``type`` field
-        # (PathType).  Adding a dict here enables dispatch; omitting it silently
-        # drops the type from the GeoJSON output.
         type_mapping: dict[str, dict[int, FrameList]] = {
             "area": hash_list.area,
             "path": hash_list.path,
@@ -582,8 +586,9 @@ class GeojsonGenerator:
         }
 
         for type_name, map_objects in type_mapping.items():
-            # Sort by hash so the per-type index is stable across runs — human-readable
-            # fallback names like "Virtual Wall 1" should not flip between invocations.
+            # Sort by hash so the per-type index is stable across runs.
+            # That keeps fallback names like "Virtual Wall 1"
+            # from flipping between invocations.
             index = 0
             for hash_key, frame_list in sorted(map_objects.items()):
                 if not GeojsonGenerator._validate_frame_list(frame_list, hash_key, area_names):
@@ -795,8 +800,9 @@ class GeojsonGenerator:
 
         return {"type": "Feature", "properties": properties, "geometry": geometry}
 
-    # Human-readable title template per PathType.  ``{n}`` is the 1-based index
-    # within the type, used when the device has no user label for this hash.
+    # Human-readable title template per PathType.
+    # ``{n}`` is the 1-based index within the type.
+    # It is used when the device has no user label for this hash.
     _NAME_TEMPLATES: ClassVar[dict[str, str]] = {
         "area": "Zone {n}",
         "path": "Path {n}",
@@ -809,7 +815,8 @@ class GeojsonGenerator:
         "visual_obstacle_zone": "Obstacle zone {n}",
     }
 
-    # Short description per PathType.  For obstacles we append " in <area>"
+    # Short description per PathType.
+    # For obstacles, append " in <area>"
     # when a parent hash is known.
     _DESCRIPTION_TEMPLATES: ClassVar[dict[str, str]] = {
         "area": "Mowing zone",
@@ -967,8 +974,8 @@ class GeojsonGenerator:
             properties.update(CORRIDOR_LINE_STYLE)
             return {"type": "LineString", "coordinates": lonlat_coords}
         if type_id == TYPE_CORRIDOR_POINT:
-            # Corridor waypoints — each coord is a separate marker in the APK.
-            # Emit a MultiPoint so every waypoint is rendered at its own location.
+            # Corridor waypoints are separate markers in the APK.
+            # Emit a MultiPoint so each waypoint renders at its own location.
             if not lonlat_coords:
                 return None
             properties.update(CORRIDOR_POINT_STYLE)

--- a/scripts/generate_live_map_geojson.py
+++ b/scripts/generate_live_map_geojson.py
@@ -1,0 +1,127 @@
+"""Generate live map GeoJSON for the first available device.
+
+Logs in, runs a full map sync, and writes the resulting
+``generated_geojson`` to ``examples/dev_output/map_{device}.geojson``.
+
+Usage:
+    EMAIL=... PASSWORD=... ./.venv/Scripts/python.exe scripts/generate_live_map_geojson.py
+
+Env var names match ``examples/dev_console.py`` — run that first if you want
+an interactive session with the same login.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+from pymammotion.client import MammotionClient
+from pymammotion.device.handle import DeviceHandle
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s  %(levelname)-7s  %(name)s  %(message)s",
+)
+for noisy in ("pymammotion.aliyun", "paho", "aiomqtt", "pymammotion.mqtt"):
+    logging.getLogger(noisy).setLevel(logging.WARNING)
+
+log = logging.getLogger("geojson_test")
+
+OUTPUT_DIR = Path(__file__).parent.parent / "examples" / "dev_output"
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+def _pick_mower(devices: list[DeviceHandle]) -> DeviceHandle | None:
+    mowers = [d for d in devices if d.device_name.startswith(("Luba", "Yuka", "Spino"))]
+    return mowers[0] if mowers else (devices[0] if devices else None)
+
+
+async def _login_with_retry(client: MammotionClient, email: str, password: str, attempts: int = 3) -> None:
+    delay = 2.0
+    for attempt in range(1, attempts + 1):
+        try:
+            await client.login_and_initiate_cloud(email, password)
+            return
+        except Exception as exc:
+            log.warning("Login attempt %d/%d failed: %s", attempt, attempts, exc)
+            if attempt == attempts:
+                raise
+            await asyncio.sleep(delay)
+            delay *= 2
+
+
+async def _wait_for_map_sync(handle: DeviceHandle, timeout: float = 180.0) -> bool:
+    """Poll handle.has_queued_commands until the map saga completes or we time out."""
+    import time as _time
+    deadline = _time.monotonic() + timeout
+    await asyncio.sleep(1.0)  # give enqueue_saga time to flip is_saga_active
+    while handle.has_queued_commands():
+        if _time.monotonic() > deadline:
+            return False
+        await asyncio.sleep(1.0)
+    return True
+
+
+async def main() -> int:
+    email = os.environ.get("EMAIL") or os.environ.get("MAMMOTION_EMAIL", "")
+    password = os.environ.get("PASSWORD") or os.environ.get("MAMMOTION_PASSWORD", "")
+    if not email or not password:
+        log.error("Set EMAIL and PASSWORD env vars")
+        return 2
+
+    client = MammotionClient()
+    log.info("Logging in as %s …", email)
+    await _login_with_retry(client, email, password)
+
+    # Let MQTT settle — dev_console.py does this too.
+    await asyncio.sleep(3)
+
+    devices = list(client.device_registry.all_devices)
+    log.info("Found %d device(s):", len(devices))
+    for d in devices:
+        log.info("  • %s  iot_id=%s", d.device_name, d.iot_id)
+
+    handle = _pick_mower(devices)
+    if handle is None:
+        log.error("No devices on this account")
+        await client.stop()
+        return 1
+    log.info("Using device: %s", handle.device_name)
+
+    # start_map_sync enqueues MapFetchSaga and wires _on_map_complete which
+    # calls device.map.generate_geojson itself — same path dev_console.py's
+    # sync_map() uses.
+    log.info("Enqueuing MapFetchSaga …")
+    await client.start_map_sync(handle.device_name)
+    completed = await _wait_for_map_sync(handle, timeout=240.0)
+    if not completed:
+        log.error("Map sync did not finish within the timeout")
+        await client.stop()
+        return 1
+    log.info("Map sync complete")
+
+    device = client.get_device_by_name(handle.device_name)
+    if device is None:
+        log.error("Device vanished from registry after sync")
+        await client.stop()
+        return 1
+
+    if not device.map.generated_geojson and device.location.RTK.latitude != 0:
+        device.map.generate_geojson(device.location.RTK, device.location.dock)
+
+    geo = device.map.generated_geojson or {"type": "FeatureCollection", "features": []}
+    out_path = OUTPUT_DIR / f"map_{handle.device_name}.geojson"
+    out_path.write_text(json.dumps(geo, indent=2), encoding="utf-8")
+    log.info("Wrote %s", out_path)
+
+    await client.stop()
+    return 0
+
+
+if __name__ == "__main__":
+    if sys.platform == "win32":
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+    sys.exit(asyncio.run(main()))

--- a/tests/test_hash_list_geojson.py
+++ b/tests/test_hash_list_geojson.py
@@ -294,6 +294,57 @@ def test_corridor_wall_and_visual_zones_emit_geojson_features() -> None:
         assert features_by_type[type_name]["geometry"]["type"] == geom_type
 
 
+def test_features_get_meaningful_names_and_descriptions() -> None:
+    """Every feature gets a non-empty Name/title and a real description.
+
+    Guards a regression where the generator emitted ``description: "description <b>test</b>"``
+    and left ``title``/``Name`` blank for any type the device hadn't user-labeled
+    (most of them — only areas carry a name_time.name).
+    """
+    fixture = _load_fixture()
+    rtk = LocationPoint(latitude=fixture["rtk"]["latitude"], longitude=fixture["rtk"]["longitude"])
+    dock = Dock(
+        latitude=fixture["dock"]["latitude"],
+        longitude=fixture["dock"]["longitude"],
+        rotation=fixture["dock"]["rotation"],
+    )
+
+    hash_list, _hashes = _hash_list_with_extra_types()
+    hash_list.generate_geojson(rtk, dock)
+    result = hash_list.generated_geojson
+
+    expected_descriptions = {
+        "corridor_line": "Corridor line between zones (MN231)",
+        "corridor_point": "Corridor waypoint between zones (MN231)",
+        "virtual_wall": "User-drawn virtual fence",
+        "visual_safety_zone": "Vision-detected safety zone",
+        "visual_obstacle_zone": "Vision-detected obstacle zone",
+    }
+    expected_name_prefix = {
+        "corridor_line": "Corridor",
+        "corridor_point": "Corridor waypoint",
+        "virtual_wall": "Virtual wall",
+        "visual_safety_zone": "Safety zone",
+        "visual_obstacle_zone": "Obstacle zone",
+    }
+
+    features_by_type = {f["properties"].get("type_name"): f for f in result["features"]}
+    for type_name, expected_desc in expected_descriptions.items():
+        feat = features_by_type.get(type_name)
+        assert feat is not None, f"missing feature for {type_name}"
+        props = feat["properties"]
+        assert props["description"] == expected_desc
+        # Name must be non-empty and start with the type-specific prefix
+        assert props["Name"], f"{type_name} has empty Name"
+        assert props["title"], f"{type_name} has empty title"
+        assert props["Name"] == props["title"], "title and Name should match"
+        assert props["Name"].startswith(expected_name_prefix[type_name]), (
+            f"{type_name} name {props['Name']!r} should start with {expected_name_prefix[type_name]!r}"
+        )
+        # The old placeholder must never come back.
+        assert "test" not in props["description"]
+
+
 def test_corridor_wall_and_visual_zone_styles_are_distinct() -> None:
     """Each new type gets its own style — colors must not collide with existing types."""
     fixture = _load_fixture()

--- a/tests/test_hash_list_geojson.py
+++ b/tests/test_hash_list_geojson.py
@@ -181,12 +181,6 @@ def test_incomplete_area_generates_no_area_features() -> None:
     assert area_features == [], "Expected no area features when area frames are incomplete"
 
 
-# ---------------------------------------------------------------------------
-# Corridor / virtual wall / visual zone GeoJSON — each PathType gets its own
-# feature with geometry and style matching the APK's layer-per-type approach.
-# ---------------------------------------------------------------------------
-
-
 def _make_frame(
     type_code: int,
     hash_id: int,

--- a/tests/test_hash_list_geojson.py
+++ b/tests/test_hash_list_geojson.py
@@ -379,6 +379,49 @@ def test_corridor_wall_and_visual_zone_styles_are_distinct() -> None:
     assert colors["visual_obstacle_zone"] == "#CC7700"
 
 
+def test_feature_styles_use_leaflet_path_options() -> None:
+    """Styles must emit Leaflet Path keys, not the common mis-spellings.
+
+    Guards against regressing to ``fill: "<color>"`` (Leaflet treats ``fill``
+    as a Boolean — the color is silently ignored, falling back to ``color``).
+    Also verifies the dead ``zIndex`` / ``road_center_*`` keys stay removed.
+    """
+    fixture = _load_fixture()
+    rtk = LocationPoint(latitude=fixture["rtk"]["latitude"], longitude=fixture["rtk"]["longitude"])
+    dock = Dock(
+        latitude=fixture["dock"]["latitude"],
+        longitude=fixture["dock"]["longitude"],
+        rotation=fixture["dock"]["rotation"],
+    )
+
+    hash_list, _hashes = _hash_list_with_extra_types()
+    hash_list.generate_geojson(rtk, dock)
+    result = hash_list.generated_geojson
+
+    for feat in result["features"]:
+        props = feat["properties"]
+        # ``fill`` must never be a color string on any feature — Leaflet would
+        # treat a non-empty string as truthy but ignore the color value.
+        if "fill" in props:
+            assert isinstance(props["fill"], bool), (
+                f"feature {props.get('type_name')!r} has fill={props['fill']!r} "
+                f"(must be bool or absent; use fillColor for colors)"
+            )
+        # Any feature that declares a fill colour must use the Leaflet key.
+        if props.get("type_name") in {
+            "area",
+            "visual_safety_zone",
+            "visual_obstacle_zone",
+            "corridor_point",
+        }:
+            assert "fillColor" in props, f"{props['type_name']} missing fillColor"
+
+        # Dead keys from the previous convention must stay out.
+        assert "zIndex" not in props
+        assert "road_center_color" not in props
+        assert "road_center_dash" not in props
+
+
 # ---------------------------------------------------------------------------
 # Yuka device — mow path generation from real device data
 # ---------------------------------------------------------------------------

--- a/tests/test_hash_list_geojson.py
+++ b/tests/test_hash_list_geojson.py
@@ -182,6 +182,153 @@ def test_incomplete_area_generates_no_area_features() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Corridor / virtual wall / visual zone GeoJSON — each PathType gets its own
+# feature with geometry and style matching the APK's layer-per-type approach.
+# ---------------------------------------------------------------------------
+
+
+def _make_frame(
+    type_code: int,
+    hash_id: int,
+    coords: list[tuple[float, float]],
+) -> NavGetCommData:
+    """Build a single-frame NavGetCommData with the given type and coord list."""
+    from pymammotion.data.model.hash_list import NavNameTime
+
+    return NavGetCommData(
+        pver=1,
+        sub_cmd=0,
+        result=0,
+        action=0,
+        type=type_code,
+        hash=hash_id,
+        paternal_hash_a=0,
+        paternal_hash_b=0,
+        total_frame=1,
+        current_frame=1,
+        data_hash=hash_id,
+        data_len=len(coords) * 16,
+        data_couple=[CommDataCouple(x=x, y=y) for x, y in coords],
+        reserved="",
+        name_time=NavNameTime(name="", create_time=0, modify_time=0),
+    )
+
+
+def _install_frame(target: dict[int, FrameList], frame: NavGetCommData) -> None:
+    target[frame.hash] = FrameList(total_frame=frame.total_frame, sub_cmd=0, data=[frame])
+
+
+def _hash_list_with_extra_types() -> tuple[HashList, dict[str, int]]:
+    """Return a HashList with one frame per new PathType and the hash IDs used."""
+    hash_list = HashList()
+    hashes = {
+        "corridor_line": 1_900_000_000_000_000_001,
+        "corridor_point": 2_000_000_000_000_000_001,
+        "virtual_wall": 2_100_000_000_000_000_001,
+        "visual_safety_zone": 2_500_000_000_000_000_001,
+        "visual_obstacle_zone": 2_600_000_000_000_000_001,
+    }
+    _install_frame(
+        hash_list.corridor_line,
+        _make_frame(19, hashes["corridor_line"], [(0.0, 0.0), (5.0, 0.0), (10.0, 0.0)]),
+    )
+    _install_frame(
+        hash_list.corridor_point,
+        _make_frame(20, hashes["corridor_point"], [(1.0, 1.0), (2.0, 2.0)]),
+    )
+    _install_frame(
+        hash_list.virtual_wall,
+        _make_frame(21, hashes["virtual_wall"], [(0.0, 3.0), (0.0, 6.0), (3.0, 6.0)]),
+    )
+    _install_frame(
+        hash_list.visual_safety_zone,
+        _make_frame(
+            25,
+            hashes["visual_safety_zone"],
+            [(4.0, 4.0), (6.0, 4.0), (6.0, 6.0), (4.0, 6.0), (4.0, 4.0)],
+        ),
+    )
+    _install_frame(
+        hash_list.visual_obstacle_zone,
+        _make_frame(
+            26,
+            hashes["visual_obstacle_zone"],
+            [(8.0, 8.0), (10.0, 8.0), (10.0, 10.0), (8.0, 10.0), (8.0, 8.0)],
+        ),
+    )
+    return hash_list, hashes
+
+
+def test_corridor_wall_and_visual_zones_emit_geojson_features() -> None:
+    """Each of the five new PathTypes (19/20/21/25/26) produces one styled feature.
+
+    Guards the two gaps the previous PR left open:
+      1. The generator's ``_process_map_objects.type_mapping`` silently dropped
+         these dicts.
+      2. ``_create_feature_geometry`` returned ``None`` for any type_id other
+         than 0/1/2, so even if dispatch worked the feature was discarded.
+    """
+    fixture = _load_fixture()
+    rtk = LocationPoint(latitude=fixture["rtk"]["latitude"], longitude=fixture["rtk"]["longitude"])
+    dock = Dock(
+        latitude=fixture["dock"]["latitude"],
+        longitude=fixture["dock"]["longitude"],
+        rotation=fixture["dock"]["rotation"],
+    )
+
+    hash_list, _hashes = _hash_list_with_extra_types()
+    hash_list.generate_geojson(rtk, dock)
+    result = hash_list.generated_geojson
+
+    features_by_type = {f["properties"].get("type_name"): f for f in result["features"]}
+
+    expected_geometry = {
+        "corridor_line": "LineString",
+        "corridor_point": "MultiPoint",
+        "virtual_wall": "LineString",
+        "visual_safety_zone": "Polygon",
+        "visual_obstacle_zone": "Polygon",
+    }
+    for type_name, geom_type in expected_geometry.items():
+        assert type_name in features_by_type, f"Expected a {type_name} feature in generator output"
+        assert features_by_type[type_name]["geometry"]["type"] == geom_type
+
+
+def test_corridor_wall_and_visual_zone_styles_are_distinct() -> None:
+    """Each new type gets its own style — colors must not collide with existing types."""
+    fixture = _load_fixture()
+    rtk = LocationPoint(latitude=fixture["rtk"]["latitude"], longitude=fixture["rtk"]["longitude"])
+    dock = Dock(
+        latitude=fixture["dock"]["latitude"],
+        longitude=fixture["dock"]["longitude"],
+        rotation=fixture["dock"]["rotation"],
+    )
+
+    hash_list, _hashes = _hash_list_with_extra_types()
+    hash_list.generate_geojson(rtk, dock)
+    result = hash_list.generated_geojson
+
+    colors = {
+        f["properties"]["type_name"]: f["properties"].get("color")
+        for f in result["features"]
+        if f["properties"].get("type_name")
+        in {
+            "corridor_line",
+            "corridor_point",
+            "virtual_wall",
+            "visual_safety_zone",
+            "visual_obstacle_zone",
+        }
+    }
+    # Color values lifted from the Mammotion Android app's MapColorTag / render code.
+    assert colors["corridor_line"] == "#145FF2"
+    assert colors["corridor_point"] == "#145FF2"
+    assert colors["virtual_wall"] == "#FF4D00"
+    assert colors["visual_safety_zone"] == "#007AFF"
+    assert colors["visual_obstacle_zone"] == "#CC7700"
+
+
+# ---------------------------------------------------------------------------
 # Yuka device — mow path generation from real device data
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Follow-up to #128 addressing the three review comments.


PR #128 made the state reducer store `VIRTUAL_WALL` (21), `CORRIDOR_LINE` (19), and `CORRIDOR_POINT` (20) frames in the right `HashList` dicts, but the GeoJSON generator had two hardcoded gaps so those frames were silently dropped again on the way out:

1. `_process_map_objects.type_mapping` only referenced `area` / `path` /  `obstacle` / `dump`, so the new dicts were never iterated.
2. `_create_feature_geometry` returned `None` for any `type_id` outside `{0, 1, 2}`, so even if dispatch had worked the feature would be discarded.

The exact same two gaps had silently blackholed the earlier `VISUAL_SAFETY_ZONE` (25) and `VISUAL_OBSTACLE_ZONE` (26) PathTypes — my HA integration works around that with its own PIL renderer (`map_renderer.py`), but any other consumer of `generate_geojson()` sees nothing.

This PR wires all five into the generator, documents the styling type used for the geojson, and populates the `Name` / `description` fields that were previously blank or contained a placeholder.

## Answering the comments

> **how does the apk request corridors?**

Same path as every other type — no new request needed. `MapFetchSaga` iterates `HashList.missing_hashlist(0)` and calls `synchronize_hash_data(hash_num=…)` per hash; the device responds with type-19/20/21 frames. #128 already added the three types to `missing_hashlist`, so the saga picks them up automatically.

> **shouldnt these form part of the geojson generator?**
> **these need styling in the geojson generator, it should in theory split by type**

Yes on both. `_process_map_objects.type_mapping` only iterated area/path/obstacle/dump, and `_create_feature_geometry` returned `None` for any `type_id ∉ {0, 1, 2}`. 
Fixed for 19/20/21 and also 25/26 (same bug from the earlier visual-zone addition). Each type gets its own geometry branch and style constant with colors lifted from the Android app's `MapColorTag`.

## Visual result — same device, same data

Luba2 with a user-drawn virtual wall and six vision-detected obstacle zones.

**Before** — 4 features; virtual wall + obstacle zones are stored but dropped:

<img width="2336" height="1353" alt="before" src="https://github.com/user-attachments/assets/c9bf9065-fc93-4a56-9c29-e6d606f18950" />

**After** — 11 features; red dashed virtual wall and orange obstacle zones render:

<img width="2336" height="1353" alt="after" src="https://github.com/user-attachments/assets/44f70ae7-f420-4413-a0f6-f2955ac5c8b5" />