### PR TITLE
Add defaults to request_iot_sys timing args

### DIFF
--- a/pymammotion/mammotion/commands/messages/system.py
+++ b/pymammotion/mammotion/commands/messages/system.py
@@ -283,10 +283,10 @@ class MessageSystem(AbstractMessage, ABC):
         self,
         rpt_act: RptAct,
         rpt_info_type: list[RptInfoType | str] | None,
-        timeout: int,
-        period: int,
-        no_change_period: int,
-        count: int,
+        timeout: int = 10000,
+        period: int = 1000,
+        no_change_period: int = 1000,
+        count: int = 1,
     ) -> bytes:
         """Configure the device IoT reporting subscription with the given action, info types, and timing parameters."""
         build = MctlSys(

--- a/uv.lock
+++ b/uv.lock
@@ -2051,7 +2051,7 @@ wheels = [
 
 [[package]]
 name = "pymammotion"
-version = "0.7.77"
+version = "0.7.78"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
So callers like request_iot_sync_continuous_stop that only need to set
the action and channels can call it without supplying timeout, period,
no_change_period, and count, instead of erroring with TypeError.

https://claude.ai/code/session_01MVx98cSTZ4rYBdoDYeznNY