### PR TITLE
Emit map_updated_bus after MapFetchSaga completes

### DIFF
--- a/pymammotion/client.py
+++ b/pymammotion/client.py
@@ -1451,6 +1451,14 @@ class MammotionClient:
                     device.map.root_hash_lists = saga.result.root_hash_lists
                 if device.location.RTK.latitude != 0:
                     device.map.generate_geojson(device.location.RTK, device.location.dock)
+                # Notify map_updated subscribers after a successful saga, matching
+                # ``handle.subscribe_map_updated`` 's docstring promise.  Without
+                # this emit, downstream subscribers (e.g. Mammotion-HA's area-switch
+                # builder) only fire on ``toapp_all_hash_name`` messages, which
+                # some Mammotion cloud sessions never deliver — leaving zone
+                # entities permanently missing even though the saga successfully
+                # populated ``device.map.area``.
+                await handle._map_updated_bus.emit(None)
 
             await handle.enqueue_saga(saga, on_complete=_on_map_complete)
         else:


### PR DESCRIPTION
## Summary

`MammotionClient.start_map_sync._on_map_complete` updates the device map after a successful `MapFetchSaga`, but never emits the `_map_updated_bus` event. The docstring on `handle.subscribe_map_updated` promises:

> "Fires when ``toapp_all_hash_name`` is received from the device or when a ``MapFetchSaga`` completes successfully."

Only the first half is implemented (in `handle.py:382-383`). When the Mammotion cloud doesn't send `toapp_all_hash_name` after a sync — which happens intermittently in normal operation — subscribers like Mammotion-HA's `async_add_area_entities` never get notified that new areas exist, even though `device.map.area` is correctly populated. The result is that some users see only a subset of their zones (or none) as switch entities.

## Reproduction

1. Define multiple lawn zones in the Mammotion mobile app (3 zones in my case)
2. Set up `mikey0000/Mammotion-HA` 0.5.33 with `pymammotion 0.7.90`
3. Trigger a map sync via the integration's "Sync maps" button
4. Observe in logs: `MapFetchSaga: map fetch complete — areas=3 obstacles=3 paths=3`
5. Check entity registry: only one (or zero) `switch.<mower>_area_*` entity exists

## Fix

One-line addition: emit `_map_updated_bus` after the saga's geojson regeneration step. This matches the docstring and brings parity with the `toapp_all_hash_name` path.

## Related

- Mammotion-HA issue #604 ("Area switches: orphaned 'unavailable' entities recreated on every map sync, only 1 of 3 defined zones appears") — partially fixed in 0.5.5 with fallback name generation, but the underlying notify gap remained.

## Testing

Verified locally by reverting all my interim workarounds (interval bumps, periodic auto-reload) and applying just this patch — all three of my zones appear as `switch.<mower>_area_area_{1,2,3}` after a single integration reload, where they previously stayed at one zone for hours of waiting.