### PR TITLE
fix: include API error code in list_binding_by_account error

### DIFF
--- a/pymammotion/aliyun/cloud_gateway.py
+++ b/pymammotion/aliyun/cloud_gateway.py
@@ -658,10 +658,13 @@ class CloudIOTGateway:
         # Load the JSON string into a dictionary
         response_body_dict = self.parse_json_response(response_body_str)
 
-        if int(response_body_dict.get("code")) != 200:
-            raise CloudSetupError(
-                f"Error listing devices by account: {response_body_dict.get('message', response_body_dict)}"
-            )
+        try:
+            code = response_body_dict.get("code", -1)
+            msg = response_body_dict.get("msg") or response_body_dict.get("message") or str(response_body_dict)
+        except (AttributeError, TypeError):
+            raise CloudSetupError(f"Error listing devices by account: {response_body_dict}") from None
+        if int(code) != 200:
+            raise CloudSetupError(f"Error listing devices by account (code={code}): {msg}")
 
         self._devices_by_account_response = ListingDevAccountResponse.from_dict(response_body_dict)
         return self._devices_by_account_response


### PR DESCRIPTION
Seen in logs:
```
  File ".../pymammotion/aliyun/cloud_gateway.py", line 662, in list_binding_by_account
    raise CloudSetupError(
        f"Error listing devices by account: {response_body_dict.get('message', response_body_dict)}"
    )
```