### PR TITLE
fix: raise ReLoginRequiredError when MQTT credentials are None

### DIFF
--- a/pymammotion/auth/token_manager.py
+++ b/pymammotion/auth/token_manager.py
@@ -483,7 +483,7 @@ class TokenManager:
             except (Exception, AuthError):
                 # Authorization code refresh also failed — fall back to a full HTTP re-login.
                 try:
-                    await self._http.refresh_login()
+                    await self.refresh_http()
                     await self._http.refresh_authorization_token()
                     creds = self._http.mqtt_credentials
                     if creds is not None:

--- a/pymammotion/client.py
+++ b/pymammotion/client.py
@@ -1214,6 +1214,8 @@ class MammotionClient:
 
         async def _refresh_jwt() -> str:
             creds = await token_manager.refresh_mqtt_creds()
+            if creds is None:
+                raise ReLoginRequiredError(token_manager.account_id, "No JWT available after credential refresh")
             return str(creds.jwt)
 
         transport = MQTTTransport(config, mammotion_http, jwt_refresher=_refresh_jwt, token_manager=token_manager)


### PR DESCRIPTION
Seen in logs:
```
  WARNING [pymammotion.transport.mqtt] Pre-connect JWT refresh failed
  ...
  File ".../pymammotion/transport/mqtt.py", line 285, in _run
    new_jwt = await self._jwt_refresher()
  File ".../pymammotion/client.py", line 1217, in _refresh_jwt
    return str(creds.jwt)
  AttributeError: 'NoneType' object has no attribute 'jwt'
```