### PR TITLE
fix: mark transport unusable on auth failure

### DIFF
--- a/pymammotion/client.py
+++ b/pymammotion/client.py
@@ -1167,12 +1167,10 @@ class MammotionClient:
             _logger.warning("Aliyun transport fatal auth error — attempting final re-login: %s", exc)
             try:
                 await self._full_relogin(acct_session)
-                # Same safety net: explicit push in case callback path was skipped.
                 if token_manager is not None:
                     creds = await token_manager.get_aliyun_credentials()
                     transport.update_iot_token(creds.iot_token)
-                # Schedule connect() for after the current _run() task exits.
-                # Calling it directly here is a no-op because the task is still running.
+                transport.clear_auth_failed()
                 asyncio.get_running_loop().call_soon(lambda: asyncio.ensure_future(transport.connect()))
                 _logger.info("Aliyun transport reconnect scheduled after final re-login")
             except Exception as relogin_exc:
@@ -1229,6 +1227,7 @@ class MammotionClient:
                 await self._full_relogin(acct_session)
                 new_jwt = await _refresh_jwt()
                 transport.update_jwt(new_jwt)
+                transport.clear_auth_failed()
                 # Schedule connect() for after the current _run() task exits.
                 asyncio.get_running_loop().call_soon(lambda: asyncio.ensure_future(transport.connect()))
                 _logger.info("MQTT transport reconnect scheduled after full re-login")

--- a/pymammotion/device/handle.py
+++ b/pymammotion/device/handle.py
@@ -1312,7 +1312,7 @@ class DeviceHandle:
                 mqtt = t
                 break
         mqtt_registered = mqtt is not None
-        mqtt_usable = mqtt_registered and not mqtt_reported_offline
+        mqtt_usable = mqtt is not None and not mqtt_reported_offline and mqtt.is_usable
 
         _logger.debug(
             "active_transport '%s': prefer_ble=%s ble_connected=%s ble_usable=%s"

--- a/pymammotion/messaging/command_queue.py
+++ b/pymammotion/messaging/command_queue.py
@@ -12,7 +12,13 @@ from typing import TYPE_CHECKING
 
 from pymammotion.aliyun.exceptions import DeviceOfflineException, TooManyRequestsException
 from pymammotion.transport import TransportError
-from pymammotion.transport.base import AuthError, NoTransportAvailableError, SagaFailedError, TransportRateLimitedError
+from pymammotion.transport.base import (
+    AuthError,
+    NoTransportAvailableError,
+    ReLoginRequiredError,
+    SagaFailedError,
+    TransportRateLimitedError,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -288,6 +294,8 @@ class DeviceCommandQueue:
                 # caller-side gate needed; just don't pollute the log.
                 if isinstance(exc, (NoTransportAvailableError, DeviceOfflineException)):
                     _logger.debug("DeviceCommandQueue[%s]: %s", self._device_name, exc)
+                elif isinstance(exc, ReLoginRequiredError):
+                    _logger.warning("DeviceCommandQueue[%s]: %s", self._device_name, exc)
                 # Real warnings — auth, saga, rate-limit, generic transport.
                 elif isinstance(
                     exc,

--- a/pymammotion/transport/aliyun_mqtt.py
+++ b/pymammotion/transport/aliyun_mqtt.py
@@ -329,6 +329,7 @@ class AliyunMQTTTransport(Transport):
         self._stop_event.set()
         self._client = None
         await self._notify_availability(TransportAvailability.DISCONNECTED)
+        self.mark_auth_failed()
         if self.on_fatal_auth_error is not None:
             with contextlib.suppress(Exception):
                 await self.on_fatal_auth_error(exc)

--- a/pymammotion/transport/base.py
+++ b/pymammotion/transport/base.py
@@ -232,6 +232,9 @@ class Transport(ABC):
         self._send_timestamps: collections.deque[float] = collections.deque()
         #: Monotonic timestamp of the most recent outbound send (0.0 = never sent).
         self._last_send_monotonic: float = 0.0
+        #: Set by mark_auth_failed() when a send fails with ReLoginRequiredError.
+        #: Cleared by clear_auth_failed() after successful credential recovery.
+        self._auth_failed: bool = False
 
     @property
     def on_message(self) -> Callable[[bytes], Awaitable[None]] | None:
@@ -317,18 +320,13 @@ class Transport(ABC):
 
     @property
     def is_usable(self) -> bool:
-        """True when this transport is in a state where ``connect()`` could plausibly succeed.
+        """True when this transport is in a state where ``send()`` could plausibly succeed.
 
-        The default implementation always returns True — applies to MQTT transports
-        whose connectability is decided by network reachability and credentials,
-        not by transport-internal state.
-
-        :class:`~pymammotion.transport.ble.BLETransport` overrides this to gate
-        on cached ``BLEDevice`` presence and connect-failure cooldown so that
-        :meth:`pymammotion.device.handle.DeviceHandle.active_transport` can
-        skip BLE without burning a connection slot during a known-bad window.
+        Returns False when an auth failure has been recorded via
+        :meth:`mark_auth_failed`.  :class:`~pymammotion.transport.ble.BLETransport`
+        overrides this to add BLEDevice-presence and cooldown gating.
         """
-        return True
+        return not self._auth_failed
 
     def set_rate_limited(self) -> None:
         """Record a rate-limit event; blocks sends on this transport for _RATE_LIMIT_DURATION seconds."""
@@ -366,6 +364,17 @@ class Transport(ABC):
             else:
                 break
         return count
+
+    def mark_auth_failed(self) -> None:
+        """Mark this transport as unusable due to an authentication failure.
+
+        ``is_usable`` returns False until ``clear_auth_failed()`` is called.
+        """
+        self._auth_failed = True
+
+    def clear_auth_failed(self) -> None:
+        """Clear the auth-failed flag after successful credential recovery."""
+        self._auth_failed = False
 
     @abstractmethod
     async def connect(self) -> None:

--- a/pymammotion/transport/ble.py
+++ b/pymammotion/transport/ble.py
@@ -160,7 +160,7 @@ class BLETransport(Transport):
         """
         if self._ble_device is None:
             return False
-        return time.monotonic() >= self._connect_cooldown_until
+        return super().is_usable and time.monotonic() >= self._connect_cooldown_until
 
     # ------------------------------------------------------------------
     # Transport ABC

--- a/pymammotion/transport/mqtt.py
+++ b/pymammotion/transport/mqtt.py
@@ -180,6 +180,12 @@ class MQTTTransport(Transport):
         if self._availability is not TransportAvailability.DISCONNECTED:
             await self._notify_availability(TransportAvailability.DISCONNECTED)
 
+    async def _fire_fatal_auth(self, exc: Exception) -> None:
+        """Fire on_fatal_auth_error if registered, suppressing callback exceptions."""
+        if self.on_fatal_auth_error is not None:
+            with contextlib.suppress(Exception):
+                await self.on_fatal_auth_error(exc)
+
     async def _invoke(self, payload: bytes, iot_id: str) -> None:
         """Invoke the Mammotion HTTP endpoint (shared by send/send_heartbeat)."""
         from pymammotion.aliyun.exceptions import DeviceOfflineException, GatewayTimeoutException
@@ -197,13 +203,21 @@ class MQTTTransport(Transport):
             _logger.info("MQTTTransport.send: HTTP access token expired — force-refreshing invoke token")
             if self._token_manager is None:
                 raise TransportError("Token manager not configured for MQTT transport") from None
-            await self._token_manager.force_refresh_invoke_token()
+            try:
+                await self._token_manager.force_refresh_invoke_token()
+            except (ReLoginRequiredError, AuthError) as refresh_exc:
+                self.mark_auth_failed()
+                await self._fire_fatal_auth(refresh_exc)
+                raise
             try:
                 res = await self._http.mqtt_invoke(content, "", iot_id)
             except UnauthorizedException as exc:
-                raise ReLoginRequiredError(
+                relogin_exc = ReLoginRequiredError(
                     self._token_manager.account_id, f"MQTT invoke still 401 after token refresh: {exc}"
-                ) from exc
+                )
+                self.mark_auth_failed()
+                await self._fire_fatal_auth(relogin_exc)
+                raise relogin_exc from exc
             except Exception as retry_exc:
                 raise AuthError(
                     f"Access token expired and retry failed after credential refresh {retry_exc}"
@@ -285,12 +299,10 @@ class MQTTTransport(Transport):
                     new_jwt = await self._jwt_refresher()
                     self._config = replace(self._config, password=new_jwt)
                 except ReLoginRequiredError as rle:
-                    # JWT refresh failed permanently — notify and surface to caller
                     _logger.error("Pre-connect JWT refresh raised ReLoginRequiredError: %s", rle)
                     self._stop_event.set()
-                    if self.on_fatal_auth_error is not None:
-                        with contextlib.suppress(Exception):
-                            await self.on_fatal_auth_error(rle)
+                    self.mark_auth_failed()
+                    await self._fire_fatal_auth(rle)
                     raise
                 except Exception:
                     _logger.warning("Pre-connect JWT refresh failed", exc_info=True)
@@ -352,17 +364,15 @@ class MQTTTransport(Transport):
                         self._token_manager.account_id,
                         f"MQTT auth exhausted after {_bad_credentials_attempts} attempt(s) (rc={rc})",
                     )
-                    if self.on_fatal_auth_error is not None:
-                        with contextlib.suppress(Exception):
-                            await self.on_fatal_auth_error(auth_exc)
+                    self.mark_auth_failed()
+                    await self._fire_fatal_auth(auth_exc)
                     raise auth_exc from exc
                 _logger.warning("MQTT error (rc=%s): %s — retry in %ds", rc, exc, backoff)
             except ReLoginRequiredError as exc:
                 _logger.error("Re-login required during MQTT connection loop: %s", exc)
                 self._stop_event.set()
-                if self.on_fatal_auth_error is not None:
-                    with contextlib.suppress(Exception):
-                        await self.on_fatal_auth_error(exc)
+                self.mark_auth_failed()
+                await self._fire_fatal_auth(exc)
                 raise
             except aiomqtt.MqttError as exc:
                 _logger.warning("MQTT disconnected: %s — retry in %ds", exc, backoff)


### PR DESCRIPTION
When MQTTTransport.send() encounters a ReLoginRequiredError the transport is marked unusable immediately via a new _auth_failed flag on Transport.
The existing on_fatal_auth_error callback drives recovery (full re-login via the client).  On success clear_auth_failed() restores the transport; on failure on_unrecoverable_auth_error fires and HA handles it.

```
send() → 401 → refresh fails → mark_auth_failed() → on_fatal_auth_error → raise
                                                         │
                                               _full_relogin() succeeds?
                                               ├─ YES → clear_auth_failed() → next command works
                                               └─ NO  → on_unrecoverable_auth_error → HA handles
                                                         transport stays unusable
                                                         commands → NoTransportAvailableError (DEBUG)
                                                         expire via TTL (120 s)
```

This requires https://github.com/mikey0000/PyMammotion/pull/142