### PR TITLE
fix: stop rate-limit WARNING from spamming the log on every send

### DIFF
--- a/pymammotion/transport/base.py
+++ b/pymammotion/transport/base.py
@@ -348,12 +348,13 @@ class Transport(ABC):
         while self._send_timestamps and self._send_timestamps[0] < cutoff:
             self._send_timestamps.popleft()
         if len(self._send_timestamps) >= self._SEND_LIMIT:
-            _logger.warning(
-                "%s: %d sends in %.0f h — self-imposing rate limit",
-                type(self).__name__,
-                len(self._send_timestamps),
-                self._SEND_WINDOW / 3600,
-            )
+            if not self.is_rate_limited:
+                _logger.warning(
+                    "%s: %d sends in %.0f h — self-imposing rate limit",
+                    type(self).__name__,
+                    len(self._send_timestamps),
+                    self._SEND_WINDOW / 3600,
+                )
             self.set_rate_limited()
 
     def sends_in_window(self) -> int:

--- a/pymammotion/transport/mqtt.py
+++ b/pymammotion/transport/mqtt.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, replace
 import json
 import logging
 import ssl
+import time
 from typing import TYPE_CHECKING
 
 from aiohttp import ClientConnectorDNSError
@@ -22,6 +23,7 @@ from pymammotion.transport.base import (
     Transport,
     TransportAvailability,
     TransportError,
+    TransportRateLimitedError,
     TransportType,
 )
 
@@ -223,6 +225,10 @@ class MQTTTransport(Transport):
 
     async def send(self, payload: bytes, iot_id: str = "") -> None:
         """Send *payload* to the device and count it against the 24-hour quota."""
+        if self.is_rate_limited:
+            remaining = self._rate_limited_until - time.monotonic()
+            msg = f"MQTTTransport rate-limited for {remaining:.0f}s more"
+            raise TransportRateLimitedError(msg)
         _logger.debug("Sending Mammotion MQTT payload: %s, %s iot_id", payload, iot_id)
         await self._invoke(payload, iot_id)
         self.record_send()


### PR DESCRIPTION
Two bugs combined to flood the log with thousands of lines like:
    
```    
      MQTTTransport: 3115 sends in 24 h — self-imposing rate limit
      MQTTTransport: 3116 sends in 24 h — self-imposing rate limit
      MQTTTransport: 3117 sends in 24 h — self-imposing rate limit
      ...
```
 
Bug 1: MQTTTransport.send() had no is_rate_limited guard. AliyunMQTTTransport.send() already checked the flag and raised
    TransportRateLimitedError before touching the network; MQTTTransport     did not, so sends continued after the 300/24 h threshold was crossed. Any path that calls transport.send() directly (e.g. the MapFetchSaga lambda in client.py) was never rate-limited.
    
Bug 2: record_send() logged the WARNING on every single send past the threshold instead of only on the first crossing.  Each call re-logged and re-called set_rate_limited(), producing one line per send indefinitely.