### PR TITLE
fix: classify Yuka Mini 2 (Yuka-ML) as YUKA_ML, not LUBA_YUKA

### DIFF
--- a/pymammotion/utility/device_type.py
+++ b/pymammotion/utility/device_type.py
@@ -435,9 +435,14 @@ class DeviceType(Enum):
 
     @staticmethod
     def is_yuka_mini(device_name: str) -> bool:
-        """Return True if the device name identifies a Yuka Mini or Yuka Mini 2 device."""
+        """Return True if the device name identifies a Yuka Mini-class device.
+
+        Covers the Yuka Mini (Yuka-MN), Yuka Mini 2 (Yuka-YM) and the Yuka Mini 2
+        ML variant (Yuka-ML / MN232). These compact, single-drive-motor units mulch
+        only (no grass collection), so this gate excludes the dump/collection entities.
+        """
         dt = DeviceType.value_of_str(device_name)
-        return dt in (DeviceType.YUKA_MINI, DeviceType.YUKA_MINI2)
+        return dt in (DeviceType.YUKA_MINI, DeviceType.YUKA_MINI2, DeviceType.YUKA_ML)
 
     @staticmethod
     def is_mini_or_x_series(device_name: str) -> bool:
@@ -447,6 +452,7 @@ class DeviceType(Enum):
             DeviceType.YUKA_MINI,
             DeviceType.YUKA_MINI2,
             DeviceType.YUKA_MINIV,
+            DeviceType.YUKA_ML,
             DeviceType.YUKA_VP,
             DeviceType.LUBA_MN,
             DeviceType.LUBA_VP,
@@ -631,13 +637,16 @@ _VALUE_OF_STR_RULES: tuple[tuple["DeviceType", int, Callable[[str], bool] | None
     (DeviceType.YUKA_VP, 7, None),
     (DeviceType.YUKA_MINI, 7, None),
     (DeviceType.YUKA_MINI2, 7, None),
-    (DeviceType.LUBA_YUKA, 7, None),
     (DeviceType.RTK3A1, 7, None),
     (DeviceType.RTK3A0, 7, None),
     (DeviceType.RTK3A2, 7, None),
     (DeviceType.YUKA_MINIV, 7, None),
     (DeviceType.LUBA_VA, 7, None),
     (DeviceType.YUKA_ML, 7, None),
+    # Generic "Yuka-" (the original Yuka) must come AFTER every specific "Yuka-XX"
+    # prefix (Yuka-MV, Yuka-ML, ...): its name is a substring of theirs, so placing
+    # it earlier shadowed them (e.g. "Yuka-ML744..." resolved to LUBA_YUKA, not YUKA_ML).
+    (DeviceType.LUBA_YUKA, 7, None),
     (DeviceType.LUBA_MD, 7, None),
     (DeviceType.LUBA_LA, 7, None),
     (DeviceType.SWIMMINGPOOL_S1, 8, None),

--- a/tests/test_device_type_lookup_refactor.py
+++ b/tests/test_device_type_lookup_refactor.py
@@ -55,7 +55,8 @@ _FROM_VALUE_REFERENCE = {
 
 
 def _reference_value_of_str(device_name: str, product_key: str = "") -> DeviceType:
-    """Verbatim transcription of the original value_of_str if-chain."""
+    """Transcription of the value_of_str if-chain (with the LUBA_YUKA ordering fix:
+    the generic "Yuka-" check follows the specific Yuka-XX prefixes)."""
     if not device_name and not product_key:
         return DeviceType.UNKNOWN
     try:
@@ -77,8 +78,6 @@ def _reference_value_of_str(device_name: str, product_key: str = "") -> DeviceTy
             return DeviceType.YUKA_MINI
         if DeviceType.YUKA_MINI2.get_name() in substring2:
             return DeviceType.YUKA_MINI2
-        if DeviceType.LUBA_YUKA.get_name() in substring2:
-            return DeviceType.LUBA_YUKA
         if DeviceType.RTK3A1.get_name() in substring2:
             return DeviceType.RTK3A1
         if DeviceType.RTK3A0.get_name() in substring2:
@@ -91,6 +90,9 @@ def _reference_value_of_str(device_name: str, product_key: str = "") -> DeviceTy
             return DeviceType.LUBA_VA
         if DeviceType.YUKA_ML.get_name() in substring2:
             return DeviceType.YUKA_ML
+        # Generic "Yuka-" must follow the specific Yuka-XX prefixes (Yuka-MV, Yuka-ML).
+        if DeviceType.LUBA_YUKA.get_name() in substring2:
+            return DeviceType.LUBA_YUKA
         if DeviceType.LUBA_MD.get_name() in substring2:
             return DeviceType.LUBA_MD
         if DeviceType.LUBA_LA.get_name() in substring2:

--- a/tests/test_yuka_ml_classification.py
+++ b/tests/test_yuka_ml_classification.py
@@ -1,0 +1,47 @@
+"""Regression tests for Yuka Mini 2 (YUKA_ML / Yuka-ML / MN232) classification.
+
+The generic ``LUBA_YUKA`` rule (name prefix ``"Yuka-"``) used to be ordered before the
+specific ``YUKA_ML`` (``"Yuka-ML"``) and ``YUKA_MINIV`` (``"Yuka-MV"``) rules in
+``value_of_str``. Because ``"Yuka-"`` is a substring of those prefixes, a real Yuka Mini 2
+device name like ``"Yuka-ML744XZH"`` resolved to ``LUBA_YUKA`` (the original full-size Yuka)
+instead of ``YUKA_ML``. That misclassification meant the HA integration's capability gates
+(``is_yuka_mini`` / ``is_mini_or_x_series``) returned the wrong answers: the mower wrongly
+got full-Yuka grass-collection entities and was denied its blade-speed (cutter) and light
+controls.
+"""
+
+import pytest
+
+from pymammotion.utility.device_type import DeviceType
+
+YUKA_MINI2_NAME = "Yuka-ML744XZH"  # real device name
+
+
+def test_yuka_ml_name_resolves_to_yuka_ml() -> None:
+    assert DeviceType.value_of_str(YUKA_MINI2_NAME) is DeviceType.YUKA_ML
+
+
+def test_yuka_miniv_no_longer_shadowed() -> None:
+    """Yuka-MV (YUKA_MINIV) was shadowed by the same ordering bug."""
+    assert DeviceType.value_of_str("Yuka-MV000001") is DeviceType.YUKA_MINIV
+
+
+def test_original_yuka_still_generic() -> None:
+    """A bare Yuka- name (no specific suffix) still resolves to the original Yuka."""
+    assert DeviceType.value_of_str("Yuka-000001") is DeviceType.LUBA_YUKA
+
+
+@pytest.mark.parametrize(
+    ("predicate", "expected"),
+    [
+        ("is_yuka", True),
+        ("is_yuka_mini", True),          # mulch-only Mini 2 -> grass-collection excluded
+        ("is_mini_or_x_series", True),   # -> cutter-speed + light controls exposed
+        ("is_luba_pro", True),           # camera / voice entities preserved
+        ("has_4g", True),                # Mini 2 has cellular
+        ("is_rtk", False),               # vision-only, no RTK
+        ("is_luba1", False),
+    ],
+)
+def test_yuka_mini2_capabilities(predicate: str, expected: bool) -> None:
+    assert getattr(DeviceType, predicate)(YUKA_MINI2_NAME) is expected


### PR DESCRIPTION
## Problem
A Yuka Mini 2 (device name `Yuka-ML744XZH`, model MN232) was classified as `LUBA_YUKA` (the original full-size Yuka) instead of `YUKA_ML`. In the Home Assistant integration this made the capability gates `is_yuka_mini` / `is_mini_or_x_series` return `False`, so the mower: - **wrongly got** full-Yuka grass-collection entities (dump-grass switch, dumping interval), and - **was denied** its blade-speed (cutter) select and light switches.

## Root cause
In `value_of_str`'s rule table, the generic `LUBA_YUKA` rule (name prefix `"Yuka-"`) was ordered **before** the specific `YUKA_ML` (`"Yuka-ML"`) and `YUKA_MINIV` (`"Yuka-MV"`) rules.
Since `"Yuka-"` is a substring of those prefixes, `"Yuka-ML744XZH"` matched `LUBA_YUKA` first.
(`"Yuka-MV…"` → `YUKA_MINIV` was shadowed by the same bug.)

Separately, even with correct classification, `YUKA_ML` was absent from the `is_yuka_mini` and `is_mini_or_x_series` tuples, so the gates still wouldn't fire for it.

## Fix
- Move the generic `LUBA_YUKA` rule **below** the specific `Yuka-XX` rules so precise prefixes match first (fixes `Yuka-ML` and, as a bonus, `Yuka-MV`).
- Add `YUKA_ML` to `is_yuka_mini` and `is_mini_or_x_series` — the MN232 is a mulch-only, single-drive-motor Yuka Mini 2, so it belongs in the mini capability group.

`is_luba_pro` (camera/voice), `has_4g`, and `is_rtk` (False) are unchanged for this device.

## Verified
On real hardware (HA integration, after the fix): the `cutter_speed` select and light switches appear, the grass-collection entities are gone, the camera still streams, and voice entities are retained. The golden-reference lookup test is updated to the corrected ordering and a dedicated Yuka Mini 2 classification/capability regression test is added (`tests/test_yuka_ml_classification.py`).
A regression spot-check confirms all other device names (original Yuka, Luba variants, RTK) are unchanged.
