### PR TITLE
fix: drop redundant local time import in radar_test_send

### DIFF
--- a/pymammotion/mammotion/commands/messages/navigation.py
+++ b/pymammotion/mammotion/commands/messages/navigation.py
@@ -969,8 +969,6 @@ class MessageNavigation(AbstractMessage, ABC):
 
     def radar_test_send(self, cmd: int) -> bytes:
         """Send radar static test command. Sends to DEV_PERCEPTION instead of DEV_MAINCTL."""
-        import time as _time
-
         luba_msg = LubaMsg(
             msgtype=MsgCmdType.NAV,
             sender=MsgDevice.DEV_MOBILEAPP,
@@ -980,7 +978,7 @@ class MessageNavigation(AbstractMessage, ABC):
             version=1,
             subtype=self.user_account,
             nav=MctlNav(vision_ctrl=VisionCtrlMsg(type=1, cmd=cmd)),
-            timestamp=round(_time.time() * 1000),
+            timestamp=round(time.time() * 1000),
         )
         logger.debug(f"Send command - Radar test cmd={cmd}")
         return luba_msg.SerializeToString()


### PR DESCRIPTION
## Summary

`pymammotion/mammotion/commands/messages/navigation.py:5` already imports `time` at module scope, but `radar_test_send` reimports it locally as `_time` and uses `_time.time()`. This is a redundant reimport (pylint `W0404`) and an in-function import (`C0415`), which `CLAUDE.md` explicitly rules out:

> **No local imports inside function bodies** — always use top-level imports.

Removing the local import and using the module-level `time` directly.

## Test plan

- [ ] CI passes
- [ ] `pylint --enable=W0404,C0415,reimported,import-outside-toplevel pymammotion/mammotion/commands/messages/navigation.py` produces no output (verified locally)
- [ ] `ruff format --check` clean (verified locally)

Surfaced while surveying state for #6.