### PR TITLE
fix: tolerate missing networkInfo fields on Luba 2 AWD 3000

### DIFF
--- a/pymammotion/data/mqtt/mammotion_properties.py
+++ b/pymammotion/data/mqtt/mammotion_properties.py
@@ -103,24 +103,17 @@ class NetworkInfo(DataClassORJSONMixin):
     ssid: str
     wifi_sta_mac: str
     wifi_rssi: int
-    wifi_available: int
     bt_mac: str
     mnet_model: str
     imei: str
     fw_ver: str
     sim: str
     imsi: str
-    iccid: str
-    sim_source: str
     mnet_rssi: int
     signal: int
     mnet_link: int
     mnet_option: str
     mnet_ip: str
-    mnet_reg: str
-    mnet_rsrp: str
-    mnet_snr: str
-    mnet_enable: int
     apn_info: str
     apn_cid: int
     used_net: int
@@ -128,20 +121,27 @@ class NetworkInfo(DataClassORJSONMixin):
     mnet_dis: int
     airplane_times: int
     lsusb_num: int
-    b_tra: Annotated[BandwidthTraffic, Alias("bTra")]
-    bw_tra: Annotated[BandwidthTraffic, Alias("bwTra")]
     mnet_rx: str
     mnet_tx: str
-    m_tra: Annotated[TrafficData, Alias("mTra")]
     mnet_uniot: int
     mnet_un_getiot: int
     ssh_flag: str
     mileage: str
     work_time: str
-    wt_sec: int
     bat_cycles: str
     ip: str = ""
     apn_num: int = 0
+    wifi_available: int = 0
+    iccid: str = ""
+    sim_source: str = ""
+    mnet_reg: str = ""
+    mnet_rsrp: str = ""
+    mnet_snr: str = ""
+    mnet_enable: int = 0
+    wt_sec: int = 0
+    b_tra: Annotated[BandwidthTraffic | None, Alias("bTra")] = None
+    bw_tra: Annotated[BandwidthTraffic | None, Alias("bwTra")] = None
+    m_tra: Annotated[TrafficData | None, Alias("mTra")] = None
 
 
 @dataclass

--- a/tests/test_network_info_luba2_awd.py
+++ b/tests/test_network_info_luba2_awd.py
@@ -1,0 +1,79 @@
+"""Regression test for the Luba 2 AWD 3000 ``networkInfo`` property parse failure.
+
+The Luba 2 AWD 3000 reports a ``networkInfo`` payload that omits several
+device-class-dependent fields the model previously marked as *required*
+(``wifi_available``, ``iccid``, ``sim_source``, ``mnet_reg``, ``mnet_rsrp``,
+``mnet_snr``, ``mnet_enable``, ``wt_sec``, and the three nested traffic blocks
+``bTra`` / ``bwTra`` / ``mTra``). A single missing required field made
+``mashumaro`` raise ``MissingField``; the exception is caught at DEBUG in
+``MowerStateReducer`` / ``RTKStateReducer`` so the device stayed available but
+WiFi RSSI, IP, LTE signal, mileage, work_time, and battery_cycles never surfaced
+in Home Assistant.
+
+The payload below is a real, PII-redacted capture from a Luba 2 AWD 3000
+(see https://github.com/mikey0000/Mammotion-HA/issues/751).
+"""
+
+import json
+
+from pymammotion.data.mqtt.mammotion_properties import NetworkInfo
+
+LUBA2_AWD_NETWORK_INFO = json.dumps(
+    {
+        "ssid": "REDACTED",
+        "ip": "192.168.1.1",
+        "wifi_sta_mac": "aa:bb:cc:dd:ee:01",
+        "wifi_rssi": -44,
+        "bt_mac": "aa:bb:cc:dd:ee:02",
+        "mnet_model": "L716-EU",
+        "imei": "000000000000000",
+        "fw_ver": "17016.1000.00.38.02.17",
+        "sim": "Ready",
+        "imsi": "000000000000000",
+        "mnet_rssi": -73,
+        "signal": 3,
+        "mnet_link": 1,
+        "mnet_option": "REDACTED",
+        "mnet_ip": "10.0.0.1",
+        "used_net": 1,
+        "hub_reset": 0,
+        "mnet_dis": 0,
+        "airplane_times": 0,
+        "lsusb_num": 7,
+        "mnet_rx": "181.47MB",
+        "mnet_tx": "177.76MB",
+        "mnet_uniot": 0,
+        "mnet_un_getiot": 1,
+        "apn_num": 1,
+        "apn_info": "REDACTED",
+        "apn_cid": 1,
+        "ssh_flag": "0",
+        "mileage": "272.64 km",
+        "work_time": "324 h 3 min 42 s",
+        "bat_cycles": "120 times",
+    }
+)
+
+
+def test_luba2_awd_network_info_parses() -> None:
+    """A Luba 2 AWD 3000 networkInfo payload decodes instead of being dropped."""
+    ni = NetworkInfo.from_json(LUBA2_AWD_NETWORK_INFO)
+
+    assert ni.wifi_rssi == -44
+    assert ni.mnet_rssi == -73
+    assert ni.mnet_model == "L716-EU"
+    assert ni.mileage == "272.64 km"
+    assert ni.work_time == "324 h 3 min 42 s"
+    assert ni.bat_cycles == "120 times"
+
+    assert ni.wifi_available == 0
+    assert ni.iccid == ""
+    assert ni.sim_source == ""
+    assert ni.mnet_reg == ""
+    assert ni.mnet_rsrp == ""
+    assert ni.mnet_snr == ""
+    assert ni.mnet_enable == 0
+    assert ni.wt_sec == 0
+    assert ni.b_tra is None
+    assert ni.bw_tra is None
+    assert ni.m_tra is None


### PR DESCRIPTION
## Summary

A Luba 2 AWD 3000 reports a `networkInfo` payload that omits 11 fields the `NetworkInfo` model in `pymammotion/data/mqtt/mammotion_properties.py` marked as required: `wifi_available`, `iccid`, `sim_source`, `mnet_reg`, `mnet_rsrp`, `mnet_snr`, `mnet_enable`, `wt_sec`, and the three nested traffic blocks `bTra` / `bwTra` / `mTra`. mashumaro raises `MissingField` on the first one and the entire networkInfo deserialize aborts.

The exception is caught at DEBUG in `MowerStateReducer` (`state_reducer.py:642-653`) and `RTKStateReducer` (`:1175`), so the device stays *available* but WiFi RSSI, IP, LTE signal, mileage, work_time, and battery cycles never surface in HA.

Same shape as #153 — different field set.

## Verification

Confirmed end-to-end by running an **actual Luba 2 AWD 3000 `networkInfo` payload** (extracted from a user-supplied debug log on https://github.com/mikey0000/Mammotion-HA/issues/751) through `NetworkInfo.from_json()`:

- **Before this change**: `MissingField: Field "wifi_available" of type int is missing in NetworkInfo instance`
- **After this change**: parses cleanly; all fields the device sends populate, the 11 it doesn't send default to sensible empty values.

Regression test in `tests/test_network_info_luba2_awd.py` uses the same real payload (PII-redacted).

## Scope notes

This **does not** address the headline "device unavailable until I open the app" complaint on issue #751 — that root cause (the `NoBLEAddressKnownError` crashing the event handler) was already addressed in 0.5.48-beta → 0.6.1. This PR fixes a separate, silent quality-of-life bug for Luba 2 AWD owners whose network state never reached HA.

## Test plan

- [ ] CI passes
- [ ] `pytest tests/test_network_info_luba2_awd.py tests/test_mammotion_properties_yuka_mini2.py` — both pass locally
- [ ] No ruff/format regressions on the changed file
