### PR TITLE
fix: tolerate partial property/post payloads from any device

### DIFF
--- a/pymammotion/data/mqtt/mammotion_properties.py
+++ b/pymammotion/data/mqtt/mammotion_properties.py
@@ -253,30 +253,36 @@ class CheckData(DataClassORJSONMixin):
 
 @dataclass
 class DeviceProperties(DataClassORJSONMixin):
-    """Full set of device properties received in a Mammotion direct-MQTT properties message."""
+    """Full set of device properties received in a Mammotion direct-MQTT properties message.
 
-    device_state: Annotated[int, Alias("deviceState")]
-    battery_percentage: Annotated[int, Alias("batteryPercentage")]
-    device_version: Annotated[str, Alias("deviceVersion")]
-    knife_height: Annotated[int, Alias("knifeHeight")]
-    lora_general_config: Annotated[str, Alias("loraGeneralConfig")]
-    ext_mod: Annotated[str, Alias("extMod")]
-    int_mod: Annotated[str, Alias("intMod")]
-    iot_state: Annotated[int, Alias("iotState")]
-    iot_msg_total: Annotated[int, Alias("iotMsgTotal")]
-    iot_msg_hz: Annotated[int, Alias("iotMsgHz")]
-    lt_mr_mod: Annotated[str, Alias("ltMrMod")]
-    rt_mr_mod: Annotated[str, Alias("rtMrMod")]
-    bms_hardware_version: Annotated[str, Alias("bmsHardwareVersion")]
-    stm32_h7_version: Annotated[str, Alias("stm32H7Version")]
-    mc_boot_version: Annotated[str, Alias("mcBootVersion")]
+    Every field is optional: devices send partial ``thing.event.property.post``
+    messages carrying as few as one or two fields at a time, so any
+    individual field may be absent from any given message.
+    """
 
-    # Nested JSON objects
-    device_version_info: Annotated[DeviceVersionInfo, Alias("deviceVersionInfo")]
-    coordinate: Coordinate
-    device_other_info: Annotated[DeviceOtherInfo, Alias("deviceOtherInfo")]
-    network_info: Annotated[NetworkInfo, Alias("networkInfo")]
-    check_data: Annotated[CheckData, Alias("checkData")]
+    device_state: Annotated[int, Alias("deviceState")] = 0
+    battery_percentage: Annotated[int, Alias("batteryPercentage")] = 0
+    device_version: Annotated[str, Alias("deviceVersion")] = ""
+    knife_height: Annotated[int, Alias("knifeHeight")] = 0
+    lora_general_config: Annotated[str, Alias("loraGeneralConfig")] = ""
+    ext_mod: Annotated[str, Alias("extMod")] = ""
+    int_mod: Annotated[str, Alias("intMod")] = ""
+    iot_state: Annotated[int, Alias("iotState")] = 0
+    iot_msg_total: Annotated[int, Alias("iotMsgTotal")] = 0
+    iot_msg_hz: Annotated[int, Alias("iotMsgHz")] = 0
+    lt_mr_mod: Annotated[str, Alias("ltMrMod")] = ""
+    rt_mr_mod: Annotated[str, Alias("rtMrMod")] = ""
+    bms_hardware_version: Annotated[str, Alias("bmsHardwareVersion")] = ""
+    stm32_h7_version: Annotated[str, Alias("stm32H7Version")] = ""
+    mc_boot_version: Annotated[str, Alias("mcBootVersion")] = ""
+
+    # Nested JSON objects — None when the device did not include the field
+    # on this particular property/post.
+    device_version_info: Annotated[DeviceVersionInfo | None, Alias("deviceVersionInfo")] = None
+    coordinate: Coordinate | None = None
+    device_other_info: Annotated[DeviceOtherInfo | None, Alias("deviceOtherInfo")] = None
+    network_info: Annotated[NetworkInfo | None, Alias("networkInfo")] = None
+    check_data: Annotated[CheckData | None, Alias("checkData")] = None
     iot_id: str = ""
     left_motor_version: Annotated[str, Alias("leftMotorVersion")] = ""
     right_motor_version: Annotated[str, Alias("rightMotorVersion")] = ""

--- a/pymammotion/device/state_reducer.py
+++ b/pymammotion/device/state_reducer.py
@@ -767,24 +767,23 @@ class MowerStateReducer(StateReducer):
                 _apply_mower_fw_module(device.device_firmwares, fw_type, v)
 
         try:
-            if p.device_version_info is not None:
-                if p.device_version_info.dev_ver:
-                    device.device_firmwares.device_version = p.device_version_info.dev_ver
-                for module in p.device_version_info.fw_info:
+            if device_version_info := p.device_version_info:
+                if device_version_info.dev_ver:
+                    device.device_firmwares.device_version = device_version_info.dev_ver
+                for module in device_version_info.fw_info:
                     if module.v:
                         _apply_mower_fw_module(device.device_firmwares, module.t, module.v)
         except (AttributeError, TypeError):
             _logger.debug("MowerStateReducer: failed to apply deviceVersionInfo (mammotion)")
 
-        if p.coordinate is not None:
-            if p.coordinate.lat != 0:
-                device.location.device.latitude = p.coordinate.lat
-            if p.coordinate.lon != 0:
-                device.location.device.longitude = p.coordinate.lon
+        if coordinate := p.coordinate:
+            if coordinate.lat != 0:
+                device.location.device.latitude = coordinate.lat
+            if coordinate.lon != 0:
+                device.location.device.longitude = coordinate.lon
 
         try:
-            net = p.network_info
-            if net is not None:
+            if net := p.network_info:
                 device.mower_state.wifi_mac = net.wifi_sta_mac or device.mower_state.wifi_mac
                 device.mower_state.ble_mac = net.bt_mac or device.mower_state.ble_mac
                 device.mower_state.wifi_ssid = net.ssid or device.mower_state.wifi_ssid

--- a/pymammotion/device/state_reducer.py
+++ b/pymammotion/device/state_reducer.py
@@ -237,10 +237,7 @@ class MowerStateReducer(StateReducer):
                         device.mower_state = copy.deepcopy(current.mower_state)
                         device.device_firmwares = copy.deepcopy(current.device_firmwares)
                     case (
-                        "bidire_comm_cmd"
-                        | "todev_time_ctrl_light"
-                        | "toapp_lora_cfg_rsp"
-                        | "device_product_type_info"
+                        "bidire_comm_cmd" | "todev_time_ctrl_light" | "toapp_lora_cfg_rsp" | "device_product_type_info"
                     ):
                         # These handlers only touch mower_state.
                         device.mower_state = copy.deepcopy(current.mower_state)
@@ -770,32 +767,35 @@ class MowerStateReducer(StateReducer):
                 _apply_mower_fw_module(device.device_firmwares, fw_type, v)
 
         try:
-            if p.device_version_info.dev_ver:
-                device.device_firmwares.device_version = p.device_version_info.dev_ver
-            for module in p.device_version_info.fw_info:
-                if module.v:
-                    _apply_mower_fw_module(device.device_firmwares, module.t, module.v)
+            if p.device_version_info is not None:
+                if p.device_version_info.dev_ver:
+                    device.device_firmwares.device_version = p.device_version_info.dev_ver
+                for module in p.device_version_info.fw_info:
+                    if module.v:
+                        _apply_mower_fw_module(device.device_firmwares, module.t, module.v)
         except (AttributeError, TypeError):
             _logger.debug("MowerStateReducer: failed to apply deviceVersionInfo (mammotion)")
 
-            if p.coordinate.lat != 0 and p.coordinate:
+        if p.coordinate is not None:
+            if p.coordinate.lat != 0:
                 device.location.device.latitude = p.coordinate.lat
-            if p.coordinate.lon != 0 and p.coordinate:
+            if p.coordinate.lon != 0:
                 device.location.device.longitude = p.coordinate.lon
 
         try:
             net = p.network_info
-            device.mower_state.wifi_mac = net.wifi_sta_mac or device.mower_state.wifi_mac
-            device.mower_state.ble_mac = net.bt_mac or device.mower_state.ble_mac
-            device.mower_state.wifi_ssid = net.ssid or device.mower_state.wifi_ssid
-            device.mower_state.ip_address = net.ip or device.mower_state.ip_address
-            device.report_data.connect.wifi_rssi = net.wifi_rssi
-            if net.mileage:
-                device.report_data.dev.mileage = int(net.mileage)
-            if net.wt_sec is not None:
-                device.report_data.dev.work_time_sec = int(net.wt_sec)
-            if net.bat_cycles:
-                device.report_data.maintenance.bat_cycles = int(net.bat_cycles)
+            if net is not None:
+                device.mower_state.wifi_mac = net.wifi_sta_mac or device.mower_state.wifi_mac
+                device.mower_state.ble_mac = net.bt_mac or device.mower_state.ble_mac
+                device.mower_state.wifi_ssid = net.ssid or device.mower_state.wifi_ssid
+                device.mower_state.ip_address = net.ip or device.mower_state.ip_address
+                device.report_data.connect.wifi_rssi = net.wifi_rssi
+                if net.mileage:
+                    device.report_data.dev.mileage = int(net.mileage)
+                if net.wt_sec is not None:
+                    device.report_data.dev.work_time_sec = int(net.wt_sec)
+                if net.bat_cycles:
+                    device.report_data.maintenance.bat_cycles = int(net.bat_cycles)
         except (AttributeError, ValueError, TypeError):
             _logger.debug("MowerStateReducer: failed to apply networkInfo (mammotion)")
 

--- a/tests/test_mammotion_properties_partial_post.py
+++ b/tests/test_mammotion_properties_partial_post.py
@@ -1,0 +1,91 @@
+"""Regression tests for partial ``thing.event.property.post`` payloads.
+
+Mammotion devices routinely send property posts containing only a small subset
+of fields (sometimes a single field). Before this fix, ``DeviceProperties``
+marked nearly every field as required, so any partial post raised
+``MissingField`` and was silently dropped at
+``pymammotion/transport/mqtt.py:_dispatch_mammotion_properties``.
+
+Payloads here are real, PII-redacted captures from a Spino E1
+(see https://github.com/mikey0000/Mammotion-HA/issues/763).
+"""
+
+import json
+
+from pymammotion.data.mqtt.mammotion_properties import DeviceProperties
+from pymammotion.data.mqtt.properties import MammotionPropertiesMessage
+
+
+SPINO_MODEL_ONLY = json.dumps(
+    {
+        "id": "14846",
+        "version": "1.0",
+        "sys": {"ack": 1},
+        "params": {"intMod": "SPINO E1", "extMod": "SPINO E1"},
+        "method": "thing.event.property.post",
+    }
+)
+
+SPINO_FW_ONLY = json.dumps(
+    {
+        "id": "14848",
+        "version": "1.0",
+        "sys": {"ack": 1},
+        "params": {
+            "deviceVersion": "1.15.2.1039",
+            "deviceVersionInfo": json.dumps(
+                {
+                    "devVer": "1.15.2.1039",
+                    "whole": 1,
+                    "fwInfo": [
+                        {"t": "63", "c": "63-PAWG4", "v": "1.2.0.275"},
+                        {"t": "65", "c": "65-PACG4", "v": "1.2.0.279"},
+                    ],
+                }
+            ),
+        },
+        "method": "thing.event.property.post",
+    }
+)
+
+
+def test_partial_property_post_model_fields_only() -> None:
+    """A property/post carrying only ``intMod`` / ``extMod`` decodes successfully."""
+    msg = MammotionPropertiesMessage.from_json(SPINO_MODEL_ONLY)
+    p = msg.params
+
+    assert p.int_mod == "SPINO E1"
+    assert p.ext_mod == "SPINO E1"
+
+    # Absent fields default rather than raising; absent nested objects are None.
+    assert p.device_state == 0
+    assert p.battery_percentage == 0
+    assert p.device_version == ""
+    assert p.network_info is None
+    assert p.coordinate is None
+    assert p.device_other_info is None
+    assert p.device_version_info is None
+    assert p.check_data is None
+
+
+def test_partial_property_post_firmware_only() -> None:
+    """A property/post carrying only ``deviceVersion`` / ``deviceVersionInfo`` decodes successfully."""
+    msg = MammotionPropertiesMessage.from_json(SPINO_FW_ONLY)
+    p = msg.params
+
+    assert p.device_version == "1.15.2.1039"
+    assert p.device_version_info is not None
+    assert p.device_version_info.dev_ver == "1.15.2.1039"
+    assert [fw.c for fw in p.device_version_info.fw_info] == ["63-PAWG4", "65-PACG4"]
+
+    # Everything else defaults / is None.
+    assert p.battery_percentage == 0
+    assert p.network_info is None
+    assert p.coordinate is None
+
+
+def test_device_properties_accepts_empty_params() -> None:
+    """A property/post with no params at all still decodes (every field optional)."""
+    p = DeviceProperties.from_dict({})
+    assert p.device_state == 0
+    assert p.network_info is None


### PR DESCRIPTION
## Summary

Mammotion devices routinely send `thing.event.property.post` messages containing only a small subset of fields. A Spino E1 debug capture in https://github.com/mikey0000/Mammotion-HA/issues/763 showed posts with as few as 2 fields:

```
{"params":{"intMod":"SPINO E1","extMod":"SPINO E1"}, ...}
{"params":{"deviceVersion":"1.15.2.1039","deviceVersionInfo":"..."}, ...}
```

But `DeviceProperties` marked nearly every field as required, so `mashumaro` raised `MissingField` on the first absent field and every partial post was silently dropped at `_dispatch_mammotion_properties`:

```
mashumaro.exceptions.MissingField: Field "device_state" of type int is missing in DeviceProperties instance
```

Same family as #153 and #158, broader scope (any device, any partial post).

## What changes

**`DeviceProperties`** (`pymammotion/data/mqtt/mammotion_properties.py`):
- Every scalar field gets a sensible default (`0` for ints, `""` for strs).
- Every nested object becomes `T | None = None` — the post-omitted JSON-string lambdas in `serialization_strategy` already pass `None` through unchanged.

**`MowerStateReducer.apply_mammotion_properties`** (`pymammotion/device/state_reducer.py`):
- Add explicit `is not None` guards around `device_version_info` access (the existing try/except still catches AttributeError; this is for clarity).
- **Fix a pre-existing indentation bug**: the `coordinate` update block sat inside the `device_version_info` `except` handler, so it only ran when the firmware-info parse failed. Dedented to run unconditionally with its own `is not None` guard.
- Wrap the `network_info` body in `if net is not None:` so the AttributeError fall-through is no longer load-bearing.

## Verification

Confirmed end-to-end against:
- **Real Spino E1 partial payloads** from #763 (both the model-only and firmware-only variants) — both now parse cleanly with sensible defaults for absent fields.
- **Existing Yuka Mini 2 fixture** (`tests/fixtures/yuka_mini2_property_post.json`) — full-payload parsing remains unchanged; `battery_percentage=31`, `device_state=13`, `network_info.wifi_rssi=-65`, `device_other_info.iot_con_fail_min=0` all populate correctly.

New regression test in `tests/test_mammotion_properties_partial_post.py` covers both Spino variants plus an empty-params edge case.

## Scope notes

This does **not** address the headline #763 complaint (`sys_status` stuck at `PREPARE` while the Spino is supposedly cleaning). That state field comes from the protobuf `DevStatueT` path, not the JSON property/post — and the user's log capture is too short and at full battery to confirm the reporter is actually mid-clean. A longer capture during active cleaning is still needed to triage that.

## Test plan

- [ ] CI passes (the 18 pre-existing failures in `tests/messaging/test_hash_list_geojson.py` + `tests/render/test_svg_center.py` also fail on `main` and are unrelated)
- [ ] `pytest tests/test_mammotion_properties_partial_post.py tests/test_mammotion_properties_yuka_mini2.py tests/test_network_info_luba2_awd.py` — all pass locally
- [ ] `ruff format --check` clean on the touched files
