### PR TITLE
Log stream/token response, stop masking empty/non-JSON results

### DIFF
--- a/pymammotion/http/http.py
+++ b/pymammotion/http/http.py
@@ -471,12 +471,30 @@ class MammotionHTTP:
                     "Content-Type": "application/json",
                 },
             )
-            if (resp.headers.get("Content-Type") or "").startswith("application/json"):
-                data = await resp.json()
-                response = response_factory(Response[StreamSubscriptionResponse], data)
+            content_type = resp.headers.get("Content-Type") or ""
+            body = await resp.text()
+            _LOGGER.debug(
+                "stream/token response: status=%s content-type=%s body=%.500s",
+                resp.status,
+                content_type,
+                body,
+            )
+            if content_type.startswith("application/json"):
+                response = response_factory(Response[StreamSubscriptionResponse], json.loads(body))
+                if response.data is None:
+                    _LOGGER.warning(
+                        "stream/token returned JSON with no stream data (code=%s msg=%s)",
+                        response.code,
+                        response.msg,
+                    )
                 return response
 
-        return Response(code=200, msg="success")
+            _LOGGER.warning(
+                "stream/token returned non-JSON response (status=%s content-type=%s)",
+                resp.status,
+                content_type,
+            )
+            return Response(code=resp.status, msg="non-json response")
 
     @refresh_token_decorator
     async def get_video_resource(self, iot_id: str) -> Response[VideoResourceResponse]:


### PR DESCRIPTION
Diagnostic change for the recurring "No stream data available for WebRTC offer" reports (Mammotion-HA [#762](https://github.com/mikey0000/Mammotion-HA/issues/762), [#671](https://github.com/mikey0000/Mammotion-HA/issues/671)).

### Problem

`get_stream_subscription` discards the `/device-server/v1/stream/token` response body and returns a fabricated `Response(code=200, msg="success")` whenever the body is missing or non-JSON. When the cloud returns no stream data, the integration then logs `Stream token refreshed successfully` and the camera surfaces only `No stream data available for WebRTC offer` — with no visibility into what the cloud actually returned (error? empty payload? non-JSON?). Several affected users (so far all EU) cannot get past this, and the discarded body is the one thing that would tell us whether it is client-fixable or a server-side issue.

### Change

- `_LOGGER.debug` the real status / content-type / body (truncated to 500 chars).
- `_LOGGER.warning` when a JSON envelope parses but carries no `data`.
- Return the real `resp.status` with `msg="non-json response"` instead of a fake `200/success` on the non-JSON path.

Diagnostic only — the success path is unchanged, so no behavioural difference for working devices. Once this is in a build, a single capture from an affected user with `pymammotion.http: debug` will show the actual response and settle the root cause.

### Testing

- `ruff check` / `ruff format --check` clean on the changed file (no new findings).
- Full unit suite green (the only failure on this branch is the pre-existing missing `examples/dev_output/mow_progress_*.geojson` golden files, unrelated to this change).