### PR TITLE
Retry command once after session refresh instead of silently dropping it

### DIFF
--- a/pymammotion/auth/token_manager.py
+++ b/pymammotion/auth/token_manager.py
@@ -322,20 +322,34 @@ class TokenManager:
     def subscribe_handle(self, handle: DeviceHandle) -> None:
         """Subscribe to auth errors from *handle* and refresh credentials automatically.
 
+        Also wires the handle's command queue so that a command failing with
+        SessionExpiredError refreshes the credentials and is retried once,
+        instead of being dropped silently.
+
         The subscription is stored internally and lives as long as this
         TokenManager instance — no external lifetime management needed.
         """
         from pymammotion.transport.base import SessionExpiredError
 
-        async def _on_error(exc: Exception) -> None:
-            try:
-                if isinstance(exc, SessionExpiredError) and exc.transport_type == TransportType.CLOUD_MAMMOTION:
-                    await self.refresh_mqtt_credentials()
-                else:
-                    await self.refresh_aliyun_credentials()
-            except Exception:
-                pass  # refresh methods log internally; swallow here to avoid crashing the error bus
+        async def _refresh_for(exc: Exception) -> None:
+            if isinstance(exc, SessionExpiredError) and exc.transport_type == TransportType.CLOUD_MAMMOTION:
+                await self.refresh_mqtt_credentials()
+            else:
+                await self.refresh_aliyun_credentials()
 
+        async def _on_error(exc: Exception) -> None:
+            with contextlib.suppress(Exception):
+                # refresh methods log internally; swallow here to avoid crashing the error bus
+                await _refresh_for(exc)
+
+        async def _on_session_expired(exc: SessionExpiredError) -> bool:
+            try:
+                await _refresh_for(exc)
+            except Exception:
+                return False  # refresh methods log internally; the queue drops the command as before
+            return True
+
+        handle.queue.on_session_expired = _on_session_expired
         self._handle_subscriptions.append(handle.subscribe_errors(_on_error))
 
     # ------------------------------------------------------------------

--- a/pymammotion/messaging/command_queue.py
+++ b/pymammotion/messaging/command_queue.py
@@ -17,6 +17,7 @@ from pymammotion.transport.base import (
     NoTransportAvailableError,
     ReLoginRequiredError,
     SagaFailedError,
+    SessionExpiredError,
     TransportRateLimitedError,
 )
 
@@ -81,6 +82,10 @@ class DeviceCommandQueue:
         self._pending_dedup_keys: set[str] = set()
         #: Called on critical errors (AuthError, SagaFailedError) so DeviceHandle can propagate them.
         self.on_critical_error: Callable[[Exception], Awaitable[None]] | None = None
+        #: Called when a work item fails with SessionExpiredError so the owner can refresh
+        #: the expired credentials (wired by TokenManager.subscribe_handle()).  Returns True
+        #: when the refresh succeeded — the item is then retried once instead of dropped.
+        self.on_session_expired: Callable[[SessionExpiredError], Awaitable[bool]] | None = None
         #: Fired when an exclusive saga is about to start.  Clients use this to pause the
         #: rapid-report subscription so it doesn't fight the saga for the MQTT channel.
         self.on_saga_start: Callable[[], Awaitable[None]] | None = None
@@ -264,24 +269,42 @@ class DeviceCommandQueue:
                 from pymammotion.aliyun.exceptions import GatewayTimeoutException
 
                 _gateway_timeout_max = 3
-                for _attempt in range(1, _gateway_timeout_max + 1):
+                _gateway_timeouts = 0
+                _session_refresh_done = False
+                while True:
                     try:
                         await item.work()
                         break  # success — exit retry loop
                     except GatewayTimeoutException:
-                        if _attempt < _gateway_timeout_max:
+                        _gateway_timeouts += 1
+                        if _gateway_timeouts < _gateway_timeout_max:
                             _logger.warning(
                                 "DeviceCommandQueue[%s]: gateway timeout (attempt %d/%d) — retrying",
                                 self._device_name,
-                                _attempt,
+                                _gateway_timeouts,
                                 _gateway_timeout_max,
                             )
                         else:
                             _logger.warning(
                                 "DeviceCommandQueue[%s]: gateway timeout after %d attempts — dropping command",
                                 self._device_name,
-                                _attempt,
+                                _gateway_timeouts,
                             )
+                            break
+                    except SessionExpiredError as exc:
+                        # The expired session can be repaired without user action — refresh
+                        # the credentials once and retry, instead of dropping the command
+                        # and leaving the user-visible action silently without effect.
+                        if _session_refresh_done or self.on_session_expired is None:
+                            raise
+                        _session_refresh_done = True
+                        _logger.info(
+                            "DeviceCommandQueue[%s]: %s — refreshing credentials and retrying command",
+                            self._device_name,
+                            exc,
+                        )
+                        if not await self.on_session_expired(exc):
+                            raise
             except asyncio.CancelledError:
                 # stop() sets _running=False before cancelling the processor task,
                 # so CancelledError here always means we are shutting down.

--- a/tests/unit/messaging/test_command_queue.py
+++ b/tests/unit/messaging/test_command_queue.py
@@ -8,7 +8,7 @@ import pytest
 from pymammotion.messaging.broker import DeviceMessageBroker
 from pymammotion.messaging.command_queue import DeviceCommandQueue, Priority
 from pymammotion.messaging.saga import Saga
-from pymammotion.transport.base import SagaFailedError
+from pymammotion.transport.base import SagaFailedError, SessionExpiredError, TransportType
 
 
 async def test_is_saga_active_false_initially() -> None:
@@ -178,4 +178,114 @@ async def test_fifo_within_same_priority() -> None:
 
     await asyncio.sleep(0.1)
     assert order == [0, 1, 2]
+    await q.stop()
+
+
+def _session_expired() -> SessionExpiredError:
+    return SessionExpiredError(TransportType.CLOUD_ALIYUN, "identityId is blank (29003) — token refresh required")
+
+
+async def test_session_expired_refreshes_and_retries() -> None:
+    """A SessionExpiredError triggers one credential refresh and a retry of the same command."""
+    q = DeviceCommandQueue()
+    q.start()
+    attempts: list[int] = []
+    refreshes: list[SessionExpiredError] = []
+
+    async def flaky_work() -> None:
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise _session_expired()
+
+    async def on_session_expired(exc: SessionExpiredError) -> bool:
+        refreshes.append(exc)
+        return True
+
+    q.on_session_expired = on_session_expired
+    await q.enqueue(flaky_work)
+    await asyncio.sleep(0.1)
+
+    assert len(attempts) == 2
+    assert len(refreshes) == 1
+    await q.stop()
+
+
+async def test_session_expired_failed_refresh_drops_command() -> None:
+    """When the credential refresh fails the command is dropped and reported as critical."""
+    q = DeviceCommandQueue()
+    q.start()
+    attempts: list[int] = []
+    critical: list[Exception] = []
+
+    async def work() -> None:
+        attempts.append(1)
+        raise _session_expired()
+
+    async def on_session_expired(exc: SessionExpiredError) -> bool:
+        return False
+
+    async def on_critical(exc: Exception) -> None:
+        critical.append(exc)
+
+    q.on_session_expired = on_session_expired
+    q.on_critical_error = on_critical
+    await q.enqueue(work)
+    await asyncio.sleep(0.1)
+
+    assert len(attempts) == 1
+    assert len(critical) == 1
+    assert isinstance(critical[0], SessionExpiredError)
+    await q.stop()
+
+
+async def test_session_expired_retries_only_once() -> None:
+    """A second SessionExpiredError after the refresh drops the command — no refresh loop."""
+    q = DeviceCommandQueue()
+    q.start()
+    attempts: list[int] = []
+    refreshes: list[int] = []
+    critical: list[Exception] = []
+
+    async def always_expired() -> None:
+        attempts.append(1)
+        raise _session_expired()
+
+    async def on_session_expired(exc: SessionExpiredError) -> bool:
+        refreshes.append(1)
+        return True
+
+    async def on_critical(exc: Exception) -> None:
+        critical.append(exc)
+
+    q.on_session_expired = on_session_expired
+    q.on_critical_error = on_critical
+    await q.enqueue(always_expired)
+    await asyncio.sleep(0.1)
+
+    assert len(attempts) == 2
+    assert len(refreshes) == 1
+    assert len(critical) == 1
+    await q.stop()
+
+
+async def test_session_expired_without_callback_keeps_previous_behaviour() -> None:
+    """Without a wired refresh callback the command is dropped and reported as critical."""
+    q = DeviceCommandQueue()
+    q.start()
+    attempts: list[int] = []
+    critical: list[Exception] = []
+
+    async def work() -> None:
+        attempts.append(1)
+        raise _session_expired()
+
+    async def on_critical(exc: Exception) -> None:
+        critical.append(exc)
+
+    q.on_critical_error = on_critical
+    await q.enqueue(work)
+    await asyncio.sleep(0.1)
+
+    assert len(attempts) == 1
+    assert len(critical) == 1
     await q.stop()


### PR DESCRIPTION
## Problem

After a Home Assistant restart the Aliyun session sometimes comes up without an `identityId`. The first cloud command then fails with code 29003 and the command queue drops it:

```
WARNING [pymammotion.messaging.command_queue] DeviceCommandQueue[Luba-XXXXXXX]: identityId is blank (29003) — token refresh required
```

The error bus correctly triggers a credential refresh afterwards, but the command itself is already gone. From the user''s perspective a button press (e.g. **Sync Maps**) silently does nothing; only a second press after the refresh has completed works. There is no UI feedback at any point.

Observed in the wild on a Luba (HA 2026.6.1): every command in the first minutes after an HA restart was swallowed this way until the integration was manually reloaded.

## Root cause

`DeviceCommandQueue._process` treats `SessionExpiredError` like any other auth error: log a warning, fire `on_critical_error`, drop the work item. The recovery (targeted credential refresh via `TokenManager`) runs *after* the command is lost, so the action the user requested never executes.

## Fix

Following the existing callback pattern (`on_critical_error`, `on_saga_start`, ...):

- `DeviceCommandQueue` gains an `on_session_expired: Callable[[SessionExpiredError], Awaitable[bool]]` hook. When a work item raises `SessionExpiredError`, the queue invokes it once and **retries the same item** if the refresh succeeded — analogous to the existing gateway-timeout retry loop directly above.
- `TokenManager.subscribe_handle()` wires the hook to the existing targeted refresh methods (`refresh_mqtt_credentials` / `refresh_aliyun_credentials`), reusing the same transport-type dispatch as the error-bus subscriber (consolidated into a shared `_refresh_for`, which also removes a `try-except-pass`).
- Failed or repeated refreshes fall back to the previous behaviour (warning + `on_critical_error` + drop), so nothing can loop.

Sagas are restartable by design, so retrying a saga work item after the refresh is safe.

## Tests

Four new unit tests in `tests/unit/messaging/test_command_queue.py`:

- refresh succeeds → command retried exactly once, refresh called exactly once
- refresh fails → command dropped, `on_critical_error` fired (previous behaviour)
- session expires again after refresh → no refresh loop, command dropped
- no callback wired → behaviour unchanged

`uv run pytest tests/unit/messaging/test_command_queue.py -q` → 14 passed. The full `tests/unit` run shows 24 pre-existing failures that also occur on unmodified `main` (geojson/svg render tests) — unrelated to this change. `ruff format` clean, `ty check` clean, no new `ruff check` findings (net -1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)