### PR TITLE
Compute area for polygon map objects with open rings (fixes Area: 0 m2 popups)

### DIFF
--- a/pymammotion/data/model/generate_geojson.py
+++ b/pymammotion/data/model/generate_geojson.py
@@ -272,6 +272,13 @@ TYPE_SVG: int = 13
 TYPE_VISUAL_SAFETY_ZONE: int = 25
 TYPE_VISUAL_OBSTACLE_ZONE: int = 26
 
+#: Type ids rendered as GeoJSON Polygons in ``_create_feature_geometry``.  Their
+#: device frames are closed rings but usually do NOT repeat the first point, so
+#: stats must include the implicit closing segment (perimeter) and the enclosed area.
+POLYGON_TYPE_IDS: frozenset[int] = frozenset(
+    {TYPE_MOWING_ZONE, TYPE_OBSTACLE, TYPE_VISUAL_SAFETY_ZONE, TYPE_VISUAL_OBSTACLE_ZONE}
+)
+
 # Coordinate conversion constants
 METERS_PER_DEGREE: int = 111320
 
@@ -634,7 +641,10 @@ class GeojsonGenerator:
                 total_frames += len(frame_list.data)
 
                 lonlat_coords = GeojsonGenerator._convert_to_lonlat_coords(local_coords, rtk_location, yaw=yaw)
-                length, area = GeojsonGenerator.map_object_stats(local_coords)
+                # Polygon-type objects are closed rings even when the device does not
+                # repeat the first point — without this their area was always 0.0.
+                is_polygon = frame_list.data[0].type in POLYGON_TYPE_IDS
+                length, area = GeojsonGenerator.map_object_stats(local_coords, closed=is_polygon)
 
                 feature = GeojsonGenerator._create_feature(
                     hash_key,
@@ -1144,11 +1154,15 @@ class GeojsonGenerator:
         return new_lon, new_lat
 
     @staticmethod
-    def map_object_stats(coords: list[CommDataCouple]) -> Coordinate:
+    def map_object_stats(coords: list[CommDataCouple], *, closed: bool = False) -> Coordinate:
         """Calculate length and area statistics for map object coordinates.
 
         Args:
             coords: List of coordinate dictionaries with 'x' and 'y' keys
+            closed: Treat *coords* as a closed ring even when the device did not
+                repeat the first point (Polygon-type map objects).  The implicit
+                closing segment is then included in the perimeter and the
+                enclosed area is computed.
 
         Returns:
             Tuple of (length, area) in meters and square meters
@@ -1164,14 +1178,16 @@ class GeojsonGenerator:
 
         length = sum(distance(coords[i], coords[i + 1]) for i in range(len(coords) - 1))
 
-        # Open line
+        ring = coords
         if coords[0] != coords[-1]:
-            return length, 0.0
+            # Open line — only a closed ring (explicit or declared) has an area.
+            if not closed:
+                return length, 0.0
+            length += distance(coords[-1], coords[0])
+            ring = [*coords, coords[0]]
 
         # Closed Polygon - Calculate area using shoelace formula
-        area = 0.5 * abs(
-            sum(coords[i].x * coords[i + 1].y - coords[i + 1].x * coords[i].y for i in range(len(coords) - 1))
-        )
+        area = 0.5 * abs(sum(ring[i].x * ring[i + 1].y - ring[i + 1].x * ring[i].y for i in range(len(ring) - 1)))
 
         return length, area
 

--- a/pymammotion/data/model/generate_geojson.py
+++ b/pymammotion/data/model/generate_geojson.py
@@ -641,8 +641,6 @@ class GeojsonGenerator:
                 total_frames += len(frame_list.data)
 
                 lonlat_coords = GeojsonGenerator._convert_to_lonlat_coords(local_coords, rtk_location, yaw=yaw)
-                # Polygon-type objects are closed rings even when the device does not
-                # repeat the first point — without this their area was always 0.0.
                 is_polygon = frame_list.data[0].type in POLYGON_TYPE_IDS
                 length, area = GeojsonGenerator.map_object_stats(local_coords, closed=is_polygon)
 

--- a/pymammotion/data/model/generate_geojson.py
+++ b/pymammotion/data/model/generate_geojson.py
@@ -1154,7 +1154,7 @@ class GeojsonGenerator:
         return new_lon, new_lat
 
     @staticmethod
-    def map_object_stats(coords: list[CommDataCouple], *, closed: bool = False) -> Coordinate:
+    def map_object_stats(coords: list[CommDataCouple], closed: bool = False) -> Coordinate:
         """Calculate length and area statistics for map object coordinates.
 
         Args:

--- a/tests/unit/data/model/test_generate_geojson.py
+++ b/tests/unit/data/model/test_generate_geojson.py
@@ -1076,3 +1076,59 @@ def test_apply_mow_progress_geojson_unset_rtk_latitude_skipped() -> None:
     )
 
     assert device.map.generated_mow_progress_geojson == {}
+
+
+def _square(size: float = 10.0, *, close: bool = False) -> list[CommDataCouple]:
+    pts = [
+        CommDataCouple(x=0.0, y=0.0),
+        CommDataCouple(x=size, y=0.0),
+        CommDataCouple(x=size, y=size),
+        CommDataCouple(x=0.0, y=size),
+    ]
+    if close:
+        pts.append(CommDataCouple(x=0.0, y=0.0))
+    return pts
+
+
+def test_map_object_stats_open_ring_without_closed_has_no_area() -> None:
+    """Default behaviour unchanged: an open line has a length but no area."""
+    from pymammotion.data.model.generate_geojson import GeojsonGenerator
+
+    length, area = GeojsonGenerator.map_object_stats(_square())
+
+    assert length == pytest.approx(30.0)
+    assert area == 0.0
+
+
+def test_map_object_stats_open_ring_closed_true_computes_area_and_perimeter() -> None:
+    """Polygon-type device frames do not repeat the first point — closed=True
+    must include the implicit closing segment and compute the enclosed area."""
+    from pymammotion.data.model.generate_geojson import GeojsonGenerator
+
+    length, area = GeojsonGenerator.map_object_stats(_square(), closed=True)
+
+    assert length == pytest.approx(40.0)
+    assert area == pytest.approx(100.0)
+
+
+def test_map_object_stats_explicitly_closed_ring_unchanged_by_closed_flag() -> None:
+    """An already closed ring yields identical stats with and without closed=True."""
+    from pymammotion.data.model.generate_geojson import GeojsonGenerator
+
+    length, area = GeojsonGenerator.map_object_stats(_square(close=True))
+    length2, area2 = GeojsonGenerator.map_object_stats(_square(close=True), closed=True)
+
+    assert length == pytest.approx(40.0)
+    assert area == pytest.approx(100.0)
+    assert (length2, area2) == (length, area)
+
+
+def test_map_object_stats_degenerate_closed_segment_has_zero_area() -> None:
+    """Two points declared closed form an out-and-back segment with no area."""
+    from pymammotion.data.model.generate_geojson import GeojsonGenerator
+
+    coords = [CommDataCouple(x=0.0, y=0.0), CommDataCouple(x=5.0, y=0.0)]
+    length, area = GeojsonGenerator.map_object_stats(coords, closed=True)
+
+    assert length == pytest.approx(10.0)
+    assert area == 0.0


### PR DESCRIPTION
## Problem

Every mowing zone (and obstacle / visual zone) in the generated GeoJSON carries `"area": 0.0`, even though the device data describes a proper closed shape. User-visible symptom: the map popups from [ha-mammotion-assets](https://github.com/mikey0000/ha-mammotion-assets) show **"Area: 0 m²"** for every zone, while `length` shows a value.

## Root cause

`GeojsonGenerator.map_object_stats()` only computes the shoelace area when the ring is *explicitly* closed (`coords[0] == coords[-1]`). The device frames for polygon-type objects usually do **not** repeat the first point, so:

- `area` was always `0.0`, and
- `length` was the open perimeter, missing the implicit closing segment.

Verified against a real Luba zone: the GeoJSON reported `area: 0.0, length: 132.1` for a zone the mower itself reports as ~334 m²; computing the shoelace over the implicitly closed ring yields ~362 m² (outer boundary), which matches.

## Fix

- New module constant `POLYGON_TYPE_IDS` — exactly the type ids that `_create_feature_geometry` renders as GeoJSON `Polygon` (mowing zone, obstacle, visual safety/obstacle zone), so the stats decision and the geometry decision share one source of truth.
- `map_object_stats()` gains a keyword-only `closed: bool = False`. For polygon-type objects the ring is treated as implicitly closed: the closing segment is added to the perimeter and the enclosed area is computed via the existing shoelace formula.
- Behaviour for open lines (paths, corridors, virtual walls), mow paths and already-closed rings is unchanged; the mow-path call sites keep the default.

## Tests

Four new unit tests for `map_object_stats` (open ring default, open ring with `closed=True`, explicitly closed ring invariance, degenerate two-point segment).

`tests/unit/data/model/test_generate_geojson.py`: baseline on unmodified `main` is **23 failed / 10 passed** (pre-existing failures, also present without this change); with this change it is **23 failed / 14 passed** — i.e. only my four new tests are added and nothing that was green turns red. `ruff format` clean, `ty check` clean, no new `ruff check` findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)