### PR TITLE
fix: filter stale thing/properties (fall back to generateTime/gmtCreate)

### DIFF
--- a/pymammotion/transport/aliyun_mqtt.py
+++ b/pymammotion/transport/aliyun_mqtt.py
@@ -538,9 +538,11 @@ class AliyunMQTTTransport(Transport):
         as typed objects via on_device_event (thing/events) or on_device_properties
         (thing/properties).
 
-        Stale events are dropped: if ``params.time`` (Unix ms, cloud-side generation
-        time) is more than ``_STALE_EVENT_THRESHOLD_MS`` behind the current wall
-        clock, the message is logged and discarded.  This prevents buffered messages
+        Stale events are dropped: if the cloud-side envelope timestamp
+        (``params.time`` for thing/events; ``params.generateTime``/``gmtCreate``
+        for thing/properties, which do not carry ``time``) is more than
+        ``_STALE_EVENT_THRESHOLD_MS`` behind the current wall clock, the
+        message is logged and discarded.  This prevents buffered messages
         delivered after a connectivity gap from polluting device state.
         """
         # Non-protobuf: parse and forward typed event
@@ -555,7 +557,12 @@ class AliyunMQTTTransport(Transport):
             return
 
         # Drop stale buffered messages using the cloud-side envelope timestamp.
-        envelope_time_ms: int = parsed.get("params", {}).get("time", 0) or 0
+        # thing/events carry ``params.time``; thing/properties only carry
+        # ``generateTime``/``gmtCreate`` — fall back so both are filtered.
+        params = parsed.get("params", {})
+        envelope_time_ms: int = int(
+            params.get("time") or params.get("generateTime") or params.get("gmtCreate") or 0
+        )
         if envelope_time_ms > 0:
             now_ms = int(time.time() * 1000)
             age_ms = now_ms - envelope_time_ms

--- a/tests/unit/device/test_handle.py
+++ b/tests/unit/device/test_handle.py
@@ -1619,9 +1619,11 @@ async def test_stale_event_dropped(transport: AliyunMQTTTransport):
 
 
 @pytest.mark.asyncio
-async def test_event_without_time_forwarded(transport: AliyunMQTTTransport):
-    """Events with params.time=0 (missing) are not dropped."""
-    raw = _make_event_envelope(0)
+async def test_event_without_any_timestamp_forwarded(transport: AliyunMQTTTransport):
+    """Events with no usable envelope timestamp (time/generateTime/gmtCreate) are not dropped."""
+    payload = json.loads(_make_event_envelope(0))
+    payload["params"]["gmtCreate"] = 0  # the helper's fixture value would trip the fallback
+    raw = json.dumps(payload).encode()
 
     await transport._dispatch_aliyun_event("/sys/testpk/testdn/app/down/thing/events", raw)
 
@@ -1629,24 +1631,70 @@ async def test_event_without_time_forwarded(transport: AliyunMQTTTransport):
 
 
 @pytest.mark.asyncio
-async def test_stale_properties_dropped(transport: AliyunMQTTTransport):
-    """Stale thing/properties messages are also dropped."""
-    now_ms = int(time.time() * 1000)
+async def test_event_without_time_falls_back_to_gmt_create(transport: AliyunMQTTTransport):
+    """Events missing params.time are filtered via gmtCreate (stale fixture value → dropped)."""
+    raw = _make_event_envelope(0)  # helper sets gmtCreate=1714000000000 (ancient)
+
+    await transport._dispatch_aliyun_event("/sys/testpk/testdn/app/down/thing/events", raw)
+
+    transport.on_device_event.assert_not_called()
+
+
+def _make_properties_envelope(generate_time_ms: int) -> bytes:
+    """Realistic thing/properties envelope: carries generateTime/gmtCreate, NO params.time."""
     payload = {
         "method": "thing.properties",
         "id": "test-props-id",
         "version": "1.0",
         "params": {
+            "deviceType": "LawnMower",
+            "checkFailedData": {},
+            "groupIdList": [],
+            "_tenantId": "",
+            "groupId": "",
+            "categoryKey": "LawnMower",
+            "batchId": "",
+            "gmtCreate": generate_time_ms,
+            "productKey": "testpk",
+            "generateTime": generate_time_ms,
+            "deviceName": "testdn",
+            "_traceId": "",
             "iotId": "test_iot_id",
-            "time": now_ms - _STALE_EVENT_THRESHOLD_MS - 30_000,
-            "items": {},
+            "JMSXDeliveryCount": 1,
+            "checkLevel": 0,
+            "qos": 1,
+            "requestId": "1",
+            "_categoryKey": "TmallGenie.LawnMower",
+            "namespace": "",
+            "tenantId": "",
+            "thingType": "DEVICE",
+            "items": {"batteryPercentage": {"time": generate_time_ms, "value": 80}},
+            "tenantInstanceId": "",
         },
     }
-    raw = json.dumps(payload).encode()
+    return json.dumps(payload).encode()
+
+
+@pytest.mark.asyncio
+async def test_stale_properties_dropped(transport: AliyunMQTTTransport):
+    """Stale thing/properties are dropped via generateTime (they carry no params.time)."""
+    now_ms = int(time.time() * 1000)
+    raw = _make_properties_envelope(now_ms - _STALE_EVENT_THRESHOLD_MS - 30_000)
 
     await transport._dispatch_aliyun_event("/sys/testpk/testdn/app/down/thing/properties", raw)
 
     transport.on_device_properties.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fresh_properties_forwarded(transport: AliyunMQTTTransport):
+    """Fresh thing/properties (recent generateTime, no params.time) are forwarded."""
+    now_ms = int(time.time() * 1000)
+    raw = _make_properties_envelope(now_ms - 5_000)
+
+    await transport._dispatch_aliyun_event("/sys/testpk/testdn/app/down/thing/properties", raw)
+
+    transport.on_device_properties.assert_called_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #170.

`thing.properties` envelopes don't carry `params.time` (only `generateTime`/`gmtCreate` — see the `Params` model in `data/mqtt/properties.py`), so the stale-message filter in `_dispatch_aliyun_event` was skipped for them and redelivered days-old property snapshots overwrote device state. Full diagnosis with production logs in the issue.

### Changes

- `_dispatch_aliyun_event`: fall back to `params.generateTime` / `params.gmtCreate` when `params.time` is absent; docstring updated.
- `test_stale_properties_dropped`: the envelope now models the real message — all required `Params` fields, `generateTime`/`gmtCreate`, **no `params.time`** (the previous envelope carried `time`, which real properties messages don't, so the test passed while production didn't filter).
- New `test_fresh_properties_forwarded` — fresh properties (recent `generateTime`, no `time`) still reach `on_device_properties`.
- `test_event_without_time_forwarded` split into two cases reflecting the fallback semantics: no usable timestamp at all → forwarded; missing `time` but ancient `gmtCreate` → dropped.

`tests/unit/device/test_handle.py`: 81 passed.

We've been running this change as a runtime patch on a Luba mini AWD 1500 install since 2026-06-12 — the redelivered stale snapshots are now logged and dropped instead of poisoning entity state.
