### PR TITLE
Fix rate-limit gate inconsistency that silently blocks all sends for quota-free firmware

### DIFF
--- a/pymammotion/device/handle.py
+++ b/pymammotion/device/handle.py
@@ -426,12 +426,17 @@ class DeviceHandle:
         is read by :meth:`_keep_alive_loop` to skip heartbeat sends when the
         transport has seen activity within the keep-alive window.
 
-        Raises TransportRateLimitedError immediately if the transport is currently
-        rate-limited — without touching the network — so all callers (commands,
-        sagas, heartbeats) are blocked uniformly while the 12-hour ban is active.
+        Raises TransportRateLimitedError immediately if a send is currently
+        blocked — without touching the network — so all callers (commands,
+        sagas, heartbeats) are gated uniformly.  Uses the same
+        ``is_send_blocked`` predicate as ``transport.send()`` itself, so this
+        pre-check can never block a send the transport would have allowed
+        (devices on quota-free firmware are exempt at both layers).
         BLE transports are never rate-limited and are always allowed through.
         """
-        if transport.transport_type != TransportType.BLE and transport.is_rate_limited:
+        version = self.firmware_version
+
+        if transport.transport_type != TransportType.BLE and transport.is_send_blocked(version):
             raise TransportRateLimitedError(
                 f"Transport {transport.transport_type.value} is rate-limited — send blocked"
             )
@@ -447,12 +452,6 @@ class DeviceHandle:
             since_sync = time.monotonic() - self._last_mqtt_sync_monotonic.get(transport.transport_type, 0.0)
             if since_sync > _MQTT_SYNC_INTERVAL:
                 await self._send_mqtt_sync(transport, since_sync=since_sync)
-
-        version = self.snapshot.raw.update_check.current_version
-
-        # TODO do this by device type
-        if version == "1.0.0.0" and hasattr(cast(MowerDevice, self.snapshot.raw), "mower_state"):
-            version = cast(MowerDevice, self.snapshot.raw).mower_state.swversion
 
         await transport.send(payload, iot_id=self.iot_id, firmware_version=version)
         if not self._stopping:
@@ -884,6 +883,22 @@ class DeviceHandle:
     def snapshot(self) -> DeviceSnapshot:
         """The latest immutable device state snapshot."""
         return self.state_machine.current
+
+    @property
+    def firmware_version(self) -> str:
+        """Device firmware version for rate-limit / cadence decisions.
+
+        Falls back to ``mower_state.swversion`` while the update-check frame
+        still holds its "1.0.0.0" placeholder, so every consumer (the send
+        gate, the poll-cadence table, the rate-limit backoff) sees the same
+        version and can never disagree about the firmware exemption.
+        """
+        version = self.snapshot.raw.update_check.current_version
+
+        # TODO do this by device type
+        if version == "1.0.0.0" and hasattr(cast(MowerDevice, self.snapshot.raw), "mower_state"):
+            version = cast(MowerDevice, self.snapshot.raw).mower_state.swversion
+        return version
 
     def restore_device(self, device: Device) -> None:
         """Restore previously saved device state (e.g. from HA storage)."""
@@ -1611,7 +1626,11 @@ class DeviceHandle:
         try:
             await self._send_marked(transport, payload)
         except TransportRateLimitedError:
-            _logger.debug("send_raw '%s': transport rate-limited — send blocked", self.device_name)
+            _logger.warning(
+                "send_raw '%s': transport rate-limited — send blocked (%.0fs until sends resume)",
+                self.device_name,
+                transport.seconds_until_send_available(),
+            )
         except TooManyRequestsException:
             _logger.warning("send_raw '%s': rate limited by cloud — blocking MQTT sends for 12h", self.device_name)
             transport.set_rate_limited()

--- a/pymammotion/device/mqtt_loop.py
+++ b/pymammotion/device/mqtt_loop.py
@@ -16,8 +16,6 @@ import os
 import time
 from typing import TYPE_CHECKING
 
-from packaging.version import Version
-
 from pymammotion.device.ble_loop import _BLE_MODE_RECHECK_INTERVAL
 from pymammotion.device.modes import _DeviceMode
 from pymammotion.transport.base import Transport, TransportType
@@ -29,8 +27,6 @@ _logger = logging.getLogger(__name__)
 
 #: Activity-loop backoff when MQTT is rate-limited and no BLE is available.
 _RATE_LIMITED_BACKOFF: float = 43200.0  # 12 hours
-
-RATE_LIMIT_REMOVED_VERSION = Version("1.30.25.1")
 
 #: MQTT one-shot (count=1) poll cadence per device mode.  Tuned for cloud quotas.
 #: Each entry can be overridden at process startup via an environment variable:
@@ -57,9 +53,7 @@ def poll_interval(handle: DeviceHandle) -> float:
     See ``_MQTT_POLL_INTERVAL`` for the per-mode cadence table.
     """
 
-    version = handle.snapshot.raw.update_check.current_version
-
-    if Version(version) >= RATE_LIMIT_REMOVED_VERSION:
+    if not Transport._version_is_rate_limited(handle.firmware_version):  # noqa: SLF001
         return _MQTT_NEW_POLL_INTERVAL[handle.device_mode()]
 
     return _MQTT_POLL_INTERVAL[handle.device_mode()]
@@ -137,14 +131,16 @@ async def mqtt_activity_loop(handle: DeviceHandle) -> None:
             await handle.sleep_or_rearm(interval)
             continue
 
-        # Back off if MQTT is rate-limited and no BLE transport is connected.
+        # Back off if MQTT sends are blocked and no BLE transport is connected.
+        # is_send_blocked applies the firmware exemption, so quota-free devices
+        # never park the poll loop on the self-imposed send window.
         mqtt: Transport | None = None
         for tt in (TransportType.CLOUD_ALIYUN, TransportType.CLOUD_MAMMOTION):
             t = handle._transports.get(tt)  # noqa: SLF001
             if t is not None:
                 mqtt = t
                 break
-        if mqtt is not None and mqtt.is_rate_limited:
+        if mqtt is not None and mqtt.is_send_blocked(handle.firmware_version):
             ble = handle._transports.get(TransportType.BLE)  # noqa: SLF001
             if ble is None or not ble.is_connected:
                 # Back off only until sends are actually available again (the rolling

--- a/pymammotion/transport/base.py
+++ b/pymammotion/transport/base.py
@@ -23,8 +23,8 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
-#: Firmware version at which Mammotion removed the cloud send rate limit.
-#: Devices on this version or newer are exempt from the self-imposed send quota
+#: Firmware version at which devices migrated to the Mammotion MQTT broker.
+#: Devices on this version or newer are not subject to the cloud send quota
 #: (see ``Transport.is_send_blocked``).
 RATE_LIMIT_REMOVED_VERSION = Version("1.30.25.1")
 
@@ -395,7 +395,8 @@ class Transport(ABC):
 
         Callers gating an actual send should use :meth:`is_send_blocked` instead, which
         also applies the firmware exemption — devices on
-        ``RATE_LIMIT_REMOVED_VERSION``+ firmware have no cloud send quota.
+        ``RATE_LIMIT_REMOVED_VERSION``+ firmware have migrated to the Mammotion MQTT
+        broker and have no cloud send quota.
         """
         if time.monotonic() < self._rate_limited_until:
             return True
@@ -403,10 +404,10 @@ class Transport(ABC):
 
     @staticmethod
     def _version_is_rate_limited(firmware_version: str) -> bool:
-        """True when *firmware_version* predates the firmware that removed rate limiting.
+        """True when *firmware_version* predates the migration to the Mammotion MQTT broker.
 
         An unknown/unparseable version (e.g. "" before the first update-check frame)
-        is treated as pre-removal so the rate-limit gate stays engaged rather than
+        is treated as pre-migration so the rate-limit gate stays engaged rather than
         letting Version("") raise InvalidVersion out of the send path.
         """
         try:

--- a/pymammotion/transport/base.py
+++ b/pymammotion/transport/base.py
@@ -11,6 +11,8 @@ import socket
 import time
 from typing import TYPE_CHECKING, Generic, Self, TypeVar
 
+from packaging.version import InvalidVersion, Version
+
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
@@ -20,6 +22,11 @@ if TYPE_CHECKING:
 
 _logger = logging.getLogger(__name__)
 T = TypeVar("T")
+
+#: Firmware version at which Mammotion removed the cloud send rate limit.
+#: Devices on this version or newer are exempt from the self-imposed send quota
+#: (see ``Transport.is_send_blocked``).
+RATE_LIMIT_REMOVED_VERSION = Version("1.30.25.1")
 
 
 class TransportError(Exception):
@@ -385,10 +392,39 @@ class Transport(ABC):
         * **Self-imposed quota** — the rolling send window currently holds ``>= _SEND_LIMIT``
           sends.  This is computed live, so it releases the moment enough of the oldest sends
           age out of the window — no fixed wait once back under the limit.
+
+        Callers gating an actual send should use :meth:`is_send_blocked` instead, which
+        also applies the firmware exemption — devices on
+        ``RATE_LIMIT_REMOVED_VERSION``+ firmware have no cloud send quota.
         """
         if time.monotonic() < self._rate_limited_until:
             return True
         return self.sends_in_window() >= self._SEND_LIMIT
+
+    @staticmethod
+    def _version_is_rate_limited(firmware_version: str) -> bool:
+        """True when *firmware_version* predates the firmware that removed rate limiting.
+
+        An unknown/unparseable version (e.g. "" before the first update-check frame)
+        is treated as pre-removal so the rate-limit gate stays engaged rather than
+        letting Version("") raise InvalidVersion out of the send path.
+        """
+        try:
+            return Version(firmware_version) < RATE_LIMIT_REMOVED_VERSION
+        except InvalidVersion:
+            return True
+
+    def is_send_blocked(self, firmware_version: str) -> bool:
+        """Return True when an outbound send must be refused for a device on *firmware_version*.
+
+        The single source of truth for the rate-limit gate: combines
+        :attr:`is_rate_limited` with the firmware exemption
+        (``RATE_LIMIT_REMOVED_VERSION``).  Every send path — ``send()`` itself and
+        any caller that pre-checks before touching the network — must use this
+        predicate rather than ``is_rate_limited`` directly, so the gates can never
+        disagree about whether a send is allowed.
+        """
+        return self.is_rate_limited and self._version_is_rate_limited(firmware_version)
 
     def seconds_until_send_available(self) -> float:
         """Seconds until a send would be allowed again (``0.0`` if allowed right now).

--- a/pymammotion/transport/mqtt.py
+++ b/pymammotion/transport/mqtt.py
@@ -15,13 +15,13 @@ from urllib.parse import urlparse
 from aiohttp import ClientConnectorDNSError
 import aiomqtt
 import jwt
-from packaging.version import InvalidVersion, Version
 
 from pymammotion.aliyun.exceptions import DeviceOfflineException, GatewayTimeoutException
 from pymammotion.data.mqtt.properties import MammotionPropertiesMessage, ThingPropertiesMessage
 from pymammotion.data.mqtt.status import MammotionStatusMessage, ThingStatusMessage
 from pymammotion.http.model.http import UnauthorizedExceptionError
 from pymammotion.transport.base import (
+    RATE_LIMIT_REMOVED_VERSION,  # noqa: F401 — re-exported for backwards compatibility
     AuthError,
     NoTransportAvailableError,
     ReLoginRequiredError,
@@ -42,7 +42,6 @@ _logger = logging.getLogger(__name__)
 
 _MQTT_RECONNECT_MIN_SEC = 1
 _MQTT_RECONNECT_MAX_SEC = 120
-RATE_LIMIT_REMOVED_VERSION = Version("1.30.25.1")
 
 
 def _jwt_claims_summary(token: str | None) -> str:
@@ -340,7 +339,7 @@ class MQTTTransport(Transport):
 
     async def send(self, payload: bytes, iot_id: str = "", firmware_version: str = "1.0.0.0") -> None:
         """Send *payload* to the device and count it against the send quota."""
-        if self.is_rate_limited and self._version_is_rate_limited(firmware_version):
+        if self.is_send_blocked(firmware_version):
             remaining = self.seconds_until_send_available()
             msg = f"MQTTTransport rate-limited for {remaining:.0f}s more"
             raise TransportRateLimitedError(msg)
@@ -351,19 +350,6 @@ class MQTTTransport(Transport):
     async def send_heartbeat(self, payload: bytes, iot_id: str = "") -> None:
         """Send a keepalive heartbeat without counting it against the send quota."""
         await self._invoke(payload, iot_id)
-
-    @staticmethod
-    def _version_is_rate_limited(firmware_version: str) -> bool:
-        """True when *firmware_version* predates the firmware that removed rate limiting.
-
-        An unknown/unparseable version (e.g. "" before the first update-check frame)
-        is treated as pre-removal so the rate-limit gate stays engaged rather than
-        letting Version("") raise InvalidVersion out of the send path.
-        """
-        try:
-            return Version(firmware_version) < RATE_LIMIT_REMOVED_VERSION
-        except InvalidVersion:
-            return True
 
     # ------------------------------------------------------------------
     # Internal

--- a/tests/integration/test_command_roundtrip.py
+++ b/tests/integration/test_command_roundtrip.py
@@ -39,6 +39,8 @@ def _make_transport(transport_type: TransportType, *, connected: bool = True) ->
     transport.transport_type = transport_type
     transport.is_connected = connected
     transport.is_rate_limited = False
+    transport.is_send_blocked = MagicMock(return_value=False)
+    transport.seconds_until_send_available = MagicMock(return_value=0.0)
     transport.last_send_monotonic = 0.0  # 0.0 = never sent (matches Transport base default)
     transport.send = AsyncMock()
     transport.send_heartbeat = AsyncMock()

--- a/tests/unit/device/test_handle.py
+++ b/tests/unit/device/test_handle.py
@@ -709,6 +709,8 @@ def _make_mqtt_transport(*, connected: bool = True) -> MagicMock:
     t.transport_type = TransportType.CLOUD_ALIYUN
     t.is_connected = connected
     t.is_rate_limited = False
+    t.is_send_blocked = MagicMock(return_value=False)
+    t.seconds_until_send_available = MagicMock(return_value=0.0)
     t.send = AsyncMock()
     t.send_heartbeat = AsyncMock()
     t.set_rate_limited = MagicMock()
@@ -853,6 +855,7 @@ async def test_send_marked_raises_when_transport_rate_limited() -> None:
     handle = _make_rl_handle()
     mqtt = _make_mqtt_transport()
     mqtt.is_rate_limited = True
+    mqtt.is_send_blocked = MagicMock(return_value=True)
     handle._transports[TransportType.CLOUD_ALIYUN] = mqtt  # noqa: SLF001
 
     with pytest.raises(TransportRateLimitedError):
@@ -895,6 +898,7 @@ async def test_send_raw_blocked_silently_when_already_rate_limited() -> None:
     handle = _make_rl_handle()
     mqtt = _make_mqtt_transport()
     mqtt.is_rate_limited = True
+    mqtt.is_send_blocked = MagicMock(return_value=True)
     handle._transports[TransportType.CLOUD_ALIYUN] = mqtt  # noqa: SLF001
 
     await handle.send_raw(b"\x00")
@@ -942,6 +946,7 @@ async def test_send_raw_guard_does_not_call_set_rate_limited_again() -> None:
     handle = _make_rl_handle()
     mqtt = _make_mqtt_transport()
     mqtt.is_rate_limited = True
+    mqtt.is_send_blocked = MagicMock(return_value=True)
     handle._transports[TransportType.CLOUD_ALIYUN] = mqtt  # noqa: SLF001
 
     # Call send_raw three times while the transport is already rate-limited.
@@ -1243,6 +1248,8 @@ def _make_transport(transport_type: TransportType, *, connected: bool = True) ->
     t.transport_type = transport_type
     t.is_connected = connected
     t.is_rate_limited = False
+    t.is_send_blocked = MagicMock(return_value=False)
+    t.seconds_until_send_available = MagicMock(return_value=0.0)
     t.last_send_monotonic = 0.0
     t.send = AsyncMock()
     t.send_heartbeat = AsyncMock()
@@ -1831,3 +1838,58 @@ async def test_device_unbound_hook_fires_only_once() -> None:
     await asyncio.sleep(0)
 
     hook.assert_awaited_once_with(handle)
+
+
+# ---------------------------------------------------------------------------
+# Firmware exemption — is_send_blocked must agree at every layer
+# (regression: _send_marked used to check is_rate_limited without the firmware
+# exemption that transport.send() applies, permanently blocking all commands
+# and sagas for quota-free-firmware devices once the window filled or a 429
+# set the ban — while telemetry kept flowing.)
+# ---------------------------------------------------------------------------
+
+
+def test_is_send_blocked_applies_firmware_exemption() -> None:
+    """is_send_blocked() must exempt firmware >= RATE_LIMIT_REMOVED_VERSION."""
+    t = _make_concrete_transport()
+    t.set_rate_limited()
+    assert t.is_rate_limited is True
+
+    # Pre-removal firmware: blocked.
+    assert t.is_send_blocked("1.11.5.0") is True
+    # Post-removal firmware (e.g. Luba Mini 2.x): exempt.
+    assert t.is_send_blocked("2.3.27.16") is False
+    # Unknown / unparseable version: fail closed (blocked).
+    assert t.is_send_blocked("") is True
+
+    # Not rate-limited at all: never blocked, regardless of firmware.
+    t._rate_limited_until = time.monotonic() - 1  # noqa: SLF001
+    assert t.is_send_blocked("1.11.5.0") is False
+
+
+async def test_send_marked_allows_exempt_firmware_while_rate_limited() -> None:
+    """_send_marked() must send when the transport exempts this firmware.
+
+    The pre-check must use the same is_send_blocked predicate as
+    transport.send() — it must never block a send the transport would allow.
+    """
+    handle = _make_rl_handle()
+    mqtt = _make_mqtt_transport()
+    mqtt.is_rate_limited = True  # quota/ban active...
+    mqtt.is_send_blocked = MagicMock(return_value=False)  # ...but firmware is exempt
+    handle._transports[TransportType.CLOUD_ALIYUN] = mqtt  # noqa: SLF001
+
+    await handle._send_marked(mqtt, b"\x01\x02\x03")  # noqa: SLF001
+
+    mqtt.send.assert_awaited_once()
+
+
+async def test_send_marked_passes_firmware_version_to_is_send_blocked() -> None:
+    """The pre-check must consult is_send_blocked with the handle's firmware version."""
+    handle = _make_rl_handle()
+    mqtt = _make_mqtt_transport()
+    handle._transports[TransportType.CLOUD_ALIYUN] = mqtt  # noqa: SLF001
+
+    await handle._send_marked(mqtt, b"\x01")  # noqa: SLF001
+
+    mqtt.is_send_blocked.assert_called_once_with(handle.firmware_version)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -466,6 +466,8 @@ def _make_connected_transport(transport_type: TransportType) -> MagicMock:
     t.transport_type = transport_type
     t.is_connected = True
     t.is_rate_limited = False
+    t.is_send_blocked = MagicMock(return_value=False)
+    t.seconds_until_send_available = MagicMock(return_value=0.0)
     t.is_usable = True  # default: ready to attempt sends; tests flip to False to exercise gates
     t.send = AsyncMock()
     t.send_heartbeat = AsyncMock()
@@ -898,6 +900,7 @@ async def test_poll_loop_rate_limited_no_ble_backs_off() -> None:
     handle = make_handle("dev1", "Luba-RL3")
     mqtt = _make_connected_transport(TransportType.CLOUD_ALIYUN)
     mqtt.is_rate_limited = True
+    mqtt.is_send_blocked = MagicMock(return_value=True)
     # The loop now backs off only until sends are available again; a full cloud ban still
     # caps at _RATE_LIMITED_BACKOFF.
     mqtt.seconds_until_send_available = MagicMock(return_value=_RATE_LIMITED_BACKOFF)
@@ -927,6 +930,7 @@ async def test_poll_loop_rate_limited_backoff_shortens_to_window_release() -> No
     handle = make_handle("dev1", "Luba-RL4")
     mqtt = _make_connected_transport(TransportType.CLOUD_ALIYUN)
     mqtt.is_rate_limited = True
+    mqtt.is_send_blocked = MagicMock(return_value=True)
     mqtt.seconds_until_send_available = MagicMock(return_value=300.0)  # window clears in 5 min
     await handle.add_transport(mqtt)
 
@@ -956,6 +960,7 @@ async def test_poll_loop_rate_limited_with_ble_still_polls() -> None:
     handle = make_handle("dev1", "Luba-RLBLE")
     mqtt = _make_connected_transport(TransportType.CLOUD_ALIYUN)
     mqtt.is_rate_limited = True
+    mqtt.is_send_blocked = MagicMock(return_value=True)
     ble = _make_connected_transport(TransportType.BLE)
     # Suppress the auto-start of BLE keepalive + polling loops so they don't race
     # with the MQTT loop under test (the polling loop would set _ble_stream_active


### PR DESCRIPTION
The bug
MqttTransport.send() exempts devices on firmware ≥ RATE_LIMIT_REMOVED_VERSION (1.30.25.1) from the send quota / 429 ban. But two other gates check bare is_rate_limited without that exemption:

DeviceHandle._send_marked's pre-check — raises TransportRateLimitedError before the transport is ever consulted. send_raw then swallows it at DEBUG level, so every command and saga send is dropped with no visible error.
mqtt_activity_loop's backoff — parks report polling for up to 12 h.
Once the rolling send window fills (or a single 429 sets the 12 h ban), a device on quota-free firmware loses all outbound commands permanently while inbound telemetry keeps flowing. From Home Assistant everything looks healthy, but:

start_mowing / dock / undock / start_mow return success and do nothing
MapFetchSaga / PlanFetchSaga time out on every attempt (their requests never leave the machine), so map_sync_status sticks at out_of_sync and map.plan stays empty
every task service fails with task_not_found forever, even right after a "successful" refresh_tasks
I suspect this is behind a good chunk of the "integration shows data but commands do nothing" reports.

The fix
Single predicate Transport.is_send_blocked(firmware_version) (quota + firmware exemption in one place), used by all three gates so they can never disagree again. _version_is_rate_limited and RATE_LIMIT_REMOVED_VERSION move to transport/base.py (re-exported from mqtt.py for compatibility; the duplicate constant in mqtt_loop.py is removed).
Firmware-version resolution (update_check with the mower_state.swversion fallback) extracted to a shared DeviceHandle.firmware_version property. This also fixes poll_interval(), which previously skipped the fallback and could raise InvalidVersion on an empty version string.
Blocked sends in send_raw now log at WARNING with seconds-until-resume instead of disappearing at DEBUG.
Testing
949 unit tests pass, no new failures (the geojson unit failure and 4 test_command_roundtrip integration failures are pre-existing on main).
3 new regression tests: the firmware exemption on is_send_blocked, the _send_marked pre-check honouring it, and the pre-check consulting handle.firmware_version.
Hardware validation (Luba Mini AWD LiDAR 1500, firmware 2.3.27.16, cloud-only — no BLE adapter)
Before (pymammotion 0.8.9 via Mammotion-HA v0.6.4-beta8): every send_raw logged transport rate-limited — send blocked; PlanFetchSaga failed 3/3 attempts with No response for 'todev_planjob_set'; map.plan empty in diagnostics; all lawn_mower commands were silent no-ops for days.

After (this patch cherry-picked onto v0.8.9, deployed to the same HA install):

MapFetchSaga completed on attempt 1   → 5/5 areas + 5/5 paths synced, map_sync_status: synced
PlanFetchSaga: fetched 3 plan(s)      → completed on attempt 1 (cloud RTT ~1 s/plan)
mammotion.start_task (front yard)     → mower physically undocked and mowed within 15 s
lawn_mower.dock                       → mower returned to dock
First time any of those had ever worked on this install.

One open question I couldn't answer from my logs (the trigger warning had scrolled out of the buffer): what originally filled the quota window / set the ban. The fix makes it moot for exempt firmware, but for pre-1.30.25.1 devices the WARNING now added to send_raw should at least make the next occurrence visible.