### PR TITLE
Fix BLE client leaks across setup and write failures

### DIFF
--- a/pymammotion/transport/ble.py
+++ b/pymammotion/transport/ble.py
@@ -31,6 +31,8 @@ if TYPE_CHECKING:
 
 _logger = logging.getLogger(__name__)
 
+_DISCONNECT_TIMEOUT_SECONDS = 2.0
+
 
 @dataclass(frozen=True)
 class BLETransportConfig:
@@ -291,17 +293,19 @@ class BLETransport(Transport):
                 self._record_connect_failure(exc)
                 raise BLEUnavailableError(f"BLE connection failed for {self._config.device_id!r}: {exc}") from exc
 
-            self._message = BleMessage(self._client)
-
-            # BlueZ may retain a stale notify subscription from a previous ungraceful
-            # disconnect.  Release it proactively so start_notify doesn't get
-            # [org.bluez.Error.NotPermitted] Notify acquired.
-            with contextlib.suppress(Exception):
-                await self._client.stop_notify(UUID_NOTIFICATION_CHARACTERISTIC)
             try:
-                await self._client.start_notify(UUID_NOTIFICATION_CHARACTERISTIC, self._notification_handler)
-            except BleakError as exc:
-                if "Notify acquired" in str(exc):
+                self._message = BleMessage(self._client)
+
+                # BlueZ may retain a stale notify subscription from a previous ungraceful
+                # disconnect.  Release it proactively so start_notify doesn't get
+                # [org.bluez.Error.NotPermitted] Notify acquired.
+                with contextlib.suppress(Exception):
+                    await self._client.stop_notify(UUID_NOTIFICATION_CHARACTERISTIC)
+                try:
+                    await self._client.start_notify(UUID_NOTIFICATION_CHARACTERISTIC, self._notification_handler)
+                except BleakError as exc:
+                    if "Notify acquired" not in str(exc):
+                        raise
                     # BlueZ reports the channel is already open — our previous
                     # connection's subscription is still live.  Notifications will
                     # continue to arrive, so there is nothing to do here.
@@ -309,26 +313,31 @@ class BLETransport(Transport):
                         "BLETransport: notify already acquired for %s — reusing existing subscription",
                         self._config.device_id,
                     )
-                else:
-                    # Tear the link down: is_connected reads the live client, so leaving
-                    # it connected here would wedge the transport into a state where
-                    # writes succeed but responses never arrive (no notify subscription).
-                    with contextlib.suppress(Exception):
-                        await self._client.disconnect()
-                    self._client = None
-                    self._message = None
+
+                await self._notify_availability(TransportAvailability.CONNECTED)
+                _logger.debug("BLETransport connected to %s", self._config.device_id)
+
+                # Successful connect resets the failure tracker.
+                self._consecutive_failures = 0
+
+                # One-shot sync on connect — subsequent periodic syncs are driven by
+                # DeviceHandle._keep_alive_loop (20 s).
+                await self._ble_sync()
+            except BaseException as exc:
+                # Once establish_connection returns, every setup failure must release
+                # the proxy/adapter slot.  Catch BaseException deliberately so task
+                # cancellation cannot strand a live client.
+                await self._teardown_client(self._client)
+                self._client = None
+                self._message = None
+                with contextlib.suppress(BaseException):
                     await self._notify_availability(TransportAvailability.DISCONNECTED)
-                    self._record_connect_failure()
-                    raise BLEUnavailableError(f"BLE start_notify failed for {self._config.device_id!r}: {exc}") from exc
-            await self._notify_availability(TransportAvailability.CONNECTED)
-            _logger.debug("BLETransport connected to %s", self._config.device_id)
-
-            # Successful connect resets the failure tracker.
-            self._consecutive_failures = 0
-
-            # One-shot sync on connect — subsequent periodic syncs are driven by
-            # DeviceHandle._keep_alive_loop (20 s).
-            await self._ble_sync()
+                self._record_connect_failure(exc if isinstance(exc, BleakError) else None)
+                if isinstance(exc, BleakError):
+                    raise BLEUnavailableError(
+                        f"BLE post-connect setup failed for {self._config.device_id!r}: {exc}"
+                    ) from exc
+                raise
 
     def _record_connect_failure(self, exc: BleakError | None = None) -> None:
         """Increment the failure counter; clear device and start cooldown at threshold.
@@ -406,14 +415,27 @@ class BLETransport(Transport):
 
     async def disconnect(self) -> None:
         """Gracefully disconnect the BLE client."""
-        if self._client is not None and self._client.is_connected:
-            try:
-                await self._client.disconnect()
-            except BleakError as exc:
-                _logger.warning("BLETransport[%s]: failed to disconnect: %s", self._config.device_id, exc)
+        client = self._client
         self._client = None
         self._message = None
+        await self._teardown_client(client)
         await self._notify_availability(TransportAvailability.DISCONNECTED)
+
+    async def _teardown_client(self, client: BleakClientWithServiceCache | None) -> None:
+        """Best-effort bounded teardown for every client reference.
+
+        ``is_connected`` is not a reliable teardown gate: backends can report
+        false while still holding a proxy or adapter connection slot.  Cleanup
+        errors are logged and suppressed so a caller handling another failure
+        can preserve and re-raise its original exception.
+        """
+        if client is None:
+            return
+        try:
+            async with asyncio.timeout(_DISCONNECT_TIMEOUT_SECONDS):
+                await client.disconnect()
+        except BaseException as exc:  # noqa: BLE001 - cleanup must not replace an in-flight failure
+            _logger.warning("BLETransport[%s]: failed to disconnect during teardown: %s", self._config.device_id, exc)
 
     async def _write_payload(self, payload: bytes) -> None:
         """Write *payload* over GATT. Raises TransportError on failure.
@@ -436,14 +458,16 @@ class BLETransport(Transport):
             try:
                 await self._message.post_custom_data_bytes(payload)
             except (TimeoutError, BleakError, OSError) as exc:
-                # Clear client refs immediately so is_connected returns False
-                # before _on_disconnect_async runs — prevents the ble_loop from
-                # retrying against a known-dead connection (GATT error 133 etc.).
+                # Release the live link before dropping the reference.  Otherwise
+                # the proxy/adapter slot remains occupied even though this transport
+                # advertises itself as disconnected.
+                await self._teardown_client(self._client)
                 self._client = None
                 self._message = None
                 await self._notify_availability(TransportAvailability.DISCONNECTED)
                 raise TransportError(f"BLE send failed for {self._config.device_id!r}: {exc}") from exc
             if not self._client.is_connected:
+                await self._teardown_client(self._client)
                 self._client = None
                 self._message = None
                 await self._notify_availability(TransportAvailability.DISCONNECTED)
@@ -453,7 +477,7 @@ class BLETransport(Transport):
 
     async def send(self, payload: bytes, iot_id: str = "", firmware_version: str = "1.0.0.0") -> None:
         """Frame and write payload via the BleMessage codec."""
-        _logger.debug("Sending BLE payload: %s, %s iot_id", payload, iot_id)
+        _logger.debug("Sending BLE payload: %s, %s iot_id, %s firmware", payload, iot_id, firmware_version)
         self._last_send_monotonic = time.monotonic()
         await self._write_payload(payload)
 

--- a/tests/unit/transport/test_ble.py
+++ b/tests/unit/transport/test_ble.py
@@ -13,6 +13,10 @@ from pymammotion.transport.base import NoBLEAddressKnownError, TransportAvailabi
 from pymammotion.transport.ble import BLETransport, BLETransportConfig
 
 
+class TimeoutAPIError(TimeoutError):
+    """Stand-in for a BLE proxy API timeout raised outside bleak."""
+
+
 @pytest.fixture
 def config() -> BLETransportConfig:
     return BLETransportConfig(device_id="test-device-001", ble_address="AA:BB:CC:DD:EE:FF")
@@ -135,6 +139,18 @@ async def test_disconnect_resets_is_connected(config: BLETransportConfig) -> Non
     assert fake_msg.post_custom_data_bytes.await_count == 1
 
 
+async def test_disconnect_attempts_teardown_when_client_reports_disconnected(config: BLETransportConfig) -> None:
+    """A false is_connected value must not suppress backend resource cleanup."""
+    transport = BLETransport(config)
+    fake_client = _make_fake_client(connected=False)
+    transport._client = fake_client  # noqa: SLF001
+
+    await transport.disconnect()
+
+    fake_client.disconnect.assert_awaited_once()
+    assert transport._client is None  # noqa: SLF001
+
+
 # ---------------------------------------------------------------------------
 # send() routes through BleMessage.post_custom_data_bytes
 # ---------------------------------------------------------------------------
@@ -204,6 +220,39 @@ async def test_send_propagates_bleak_error_and_marks_disconnected(config: BLETra
 
     assert transport.availability is TransportAvailability.DISCONNECTED
     assert TransportAvailability.DISCONNECTED in listener_states
+
+
+async def test_send_timeout_disconnects_live_client_before_dropping_reference(
+    config: BLETransportConfig,
+) -> None:
+    """A timed-out write must release its live client before clearing it."""
+    from pymammotion.transport.base import TransportError
+
+    transport = BLETransport(config)
+    transport.set_ble_device(MagicMock(spec=BLEDevice))
+
+    fake_client = _make_fake_client()
+    fake_msg = _make_fake_ble_message()
+
+    async def _disconnect() -> None:
+        assert transport._client is fake_client  # noqa: SLF001
+        fake_client.is_connected = False
+
+    fake_client.disconnect.side_effect = _disconnect
+
+    with (
+        patch("pymammotion.transport.ble.establish_connection", new=AsyncMock(return_value=fake_client)),
+        patch("pymammotion.transport.ble.BleMessage", return_value=fake_msg),
+    ):
+        await transport.connect()
+        fake_msg.post_custom_data_bytes.reset_mock()
+        fake_msg.post_custom_data_bytes.side_effect = TimeoutError("write timed out")
+
+        with pytest.raises(TransportError, match="write timed out"):
+            await transport.send(b"\xDE\xAD\xBE\xEF")
+
+    fake_client.disconnect.assert_awaited_once()
+    assert transport._client is None  # noqa: SLF001
 
 
 async def test_send_raises_when_client_disconnected_during_write(config: BLETransportConfig) -> None:
@@ -521,6 +570,85 @@ async def test_successful_connect_resets_failure_counter(config: BLETransportCon
         await transport.connect()
 
     assert transport._consecutive_failures == 0  # noqa: SLF001
+
+
+@pytest.mark.parametrize("setup_error", [TimeoutAPIError("notify timed out"), RuntimeError("proxy failed")])
+async def test_start_notify_non_bleak_failure_releases_client_and_preserves_exception(
+    config: BLETransportConfig,
+    setup_error: Exception,
+) -> None:
+    """Non-Bleak setup failures must disconnect and escape unchanged."""
+    transport = BLETransport(replace(config, connect_failure_threshold=3))
+    transport.set_ble_device(_ble_device_with_address("AA:BB:CC:DD:EE:FF"))
+    fake_client = _make_fake_client()
+    fake_client.start_notify.side_effect = setup_error
+
+    with patch("pymammotion.transport.ble.establish_connection", new=AsyncMock(return_value=fake_client)):
+        with pytest.raises(type(setup_error), match=str(setup_error)):
+            await transport.connect()
+
+    fake_client.disconnect.assert_awaited_once()
+    assert transport._client is None  # noqa: SLF001
+    assert transport._message is None  # noqa: SLF001
+
+
+async def test_start_notify_cancellation_releases_client_and_propagates(
+    config: BLETransportConfig,
+) -> None:
+    """Cancellation during post-connect setup must not leak the live client."""
+    transport = BLETransport(replace(config, connect_failure_threshold=3))
+    transport.set_ble_device(_ble_device_with_address("AA:BB:CC:DD:EE:FF"))
+    fake_client = _make_fake_client()
+    fake_client.start_notify.side_effect = asyncio.CancelledError
+
+    with patch("pymammotion.transport.ble.establish_connection", new=AsyncMock(return_value=fake_client)):
+        with pytest.raises(asyncio.CancelledError):
+            await transport.connect()
+
+    fake_client.disconnect.assert_awaited_once()
+    assert transport._client is None  # noqa: SLF001
+    assert transport._message is None  # noqa: SLF001
+
+
+async def test_setup_cleanup_failure_does_not_replace_original_exception(
+    config: BLETransportConfig,
+) -> None:
+    """A teardown error must not mask the setup failure that triggered it."""
+    transport = BLETransport(replace(config, connect_failure_threshold=3))
+    transport.set_ble_device(_ble_device_with_address("AA:BB:CC:DD:EE:FF"))
+    fake_client = _make_fake_client()
+    original = TimeoutAPIError("notify timed out")
+    fake_client.start_notify.side_effect = original
+    fake_client.disconnect.side_effect = RuntimeError("cleanup failed")
+
+    with patch("pymammotion.transport.ble.establish_connection", new=AsyncMock(return_value=fake_client)):
+        with pytest.raises(TimeoutAPIError, match="notify timed out") as raised:
+            await transport.connect()
+
+    assert raised.value is original
+    fake_client.disconnect.assert_awaited_once()
+
+
+async def test_repeated_setup_failures_balance_connections_and_disconnects(
+    config: BLETransportConfig,
+) -> None:
+    """Every established client must be disconnected across repeated setup failures."""
+    attempts = 3
+    transport = BLETransport(replace(config, connect_failure_threshold=attempts + 1))
+    transport.set_ble_device(_ble_device_with_address("AA:BB:CC:DD:EE:FF"))
+    clients = [_make_fake_client() for _ in range(attempts)]
+    for client in clients:
+        client.start_notify.side_effect = TimeoutError("notify timed out")
+
+    establish = AsyncMock(side_effect=clients)
+    with patch("pymammotion.transport.ble.establish_connection", new=establish):
+        for _ in range(attempts):
+            with pytest.raises(TimeoutError, match="notify timed out"):
+                await transport.connect()
+
+    assert establish.await_count == attempts
+    assert sum(client.disconnect.await_count for client in clients) == attempts
+    assert all(client.disconnect.await_count == 1 for client in clients)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed
- make post-connect BLE setup failure-atomic for timeouts, cancellation, and non-Bleak exceptions
- use one bounded teardown path for every non-null client, even when `is_connected` is false
- disconnect live clients before clearing references after write failures
- preserve the triggering exception when cleanup itself fails
- add regression coverage for timeout, cancellation, false connection state, cleanup failure, and repeated balanced attempts

## Why
A proxy or adapter connection slot can remain occupied when notification setup or a GATT write fails. Dropping `_client` without calling `disconnect()`, or gating cleanup on `is_connected`, makes subsequent reconnects accumulate leaked connections.

## Impact
BLE failures now release the underlying client within a two-second bound and leave the transport disconnected. Existing `Notify acquired` recovery behavior is retained.

## Checks
- `python -m pytest tests/unit/transport/test_ble.py -q` — 40 passed
- broader unit/integration run — 1,083 passed; one unrelated upstream test could not run because `examples/dev_output/mow_progress_1.geojson` is absent
- `ruff check pymammotion/transport/ble.py`
- `git diff --check`