### PR TITLE
Reset BluFi reassembly after dropped or corrupt frames

### DIFF
--- a/pymammotion/bluetooth/ble_message.py
+++ b/pymammotion/bluetooth/ble_message.py
@@ -330,12 +330,10 @@ class BleMessage:
         try:
             jSONObject["cmd"] = cmd
             jSONObject[tmp_constant.REQUEST_ID] = int(time.time())
-            jSONObject2: dict[str, int] = {}
-            for key, value in hash_map.items():
-                jSONObject2[key] = value
+            jSONObject2 = dict(hash_map)
             jSONObject["params"] = jSONObject2
             return json.dumps(jSONObject)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - command serialization must fail closed
             _LOGGER.debug("Failed to build JSON command string: %s", e)
             return ""
 
@@ -378,6 +376,10 @@ class BleMessage:
             )
             # Set the value for mReadSequence manually
             self.mReadSequence.set(sequence)
+            # A missing packet makes any accumulated fragments incomplete.
+            # Reset before accepting this packet so the next completed message
+            # cannot contain bytes retained from the abandoned one.
+            self.clear_notification()
 
         # LogUtil.m7773e(self.mGatt.getDevice().getName() + "打印丢包率", self.mReadSequence_2 + "/" + self.mReadSequence_1);
         pkt_type = int(response[0])  # toInt
@@ -414,14 +416,16 @@ class BleMessage:
                         f"expect checksum: {respChecksum1}, {respChecksum2}\n"
                         f"received checksum: {calcChecksum1}, {calcChecksum2}"
                     )
+                    self.clear_notification()
                     return -4
 
             data_offset = 2 if frameCtrlData.hasFrag() else 0
 
             self.notification.addData(dataBytes, data_offset)
             return 1 if frameCtrlData.hasFrag() else 0
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - malformed frames are rejected and reset
             _LOGGER.debug(e)
+            self.clear_notification()
             return -100
 
     async def parseBlufiNotifyData(self, return_bytes: bool = False) -> bytes | None:
@@ -484,7 +488,7 @@ class BleMessage:
             jSONObject["cmd"] = cmd
             jSONObject[tmp_constant.REQUEST_ID] = int(time.time())
             return json.dumps(jSONObject)
-        except Exception:
+        except Exception:  # noqa: BLE001 - legacy JSON command builder fails closed
             return ""
 
     def current_milli_time(self) -> int:
@@ -497,16 +501,16 @@ class BleMessage:
     def _getSubType(self, typeValue: int) -> int:
         return (typeValue & 252) >> 2
 
-    def getTypeValue(self, type: int, subtype: int) -> int:
+    def getTypeValue(self, package_type: int, subtype: int) -> int:
         """Encode a BluFi packet type byte from the package type and subtype values."""
-        return (subtype << 2) | type
+        return (subtype << 2) | package_type
 
     def receiveAck(self, expectAck: int) -> bool:
         """Block until an ACK is received and return True if it matches the expected sequence number."""
         try:
             ack = self.mAck.get()
             return ack == expectAck
-        except Exception as err:
+        except Exception as err:  # noqa: BLE001 - ACK queue failures mean no acknowledgement
             _LOGGER.debug(err)
             return False
 
@@ -535,7 +539,7 @@ class BleMessage:
             await self.post(self.mEncrypted, self.mChecksum, self.mRequireAck, type_val, data)
             # int status = suc ? 0 : BlufiCallback.CODE_WRITE_DATA_FAILED
             # onPostCustomDataResult(status, data)
-        except Exception as err:
+        except Exception as err:  # noqa: BLE001 - any write failure requires connection reset
             _LOGGER.debug(err)
             # we might be constantly connected and in a bad state
             self.mSendSequence = AtomicInteger(-1)
@@ -605,7 +609,7 @@ class BleMessage:
 
     def getPostBytes(
         self,
-        type: int,
+        packet_type: int,
         encrypt: bool,
         checksum: bool,
         require_ack: bool,
@@ -617,7 +621,7 @@ class BleMessage:
         byteOS = BytesIO()
         dataLength = 0 if data is None else len(data)
         frameCtrl = FrameCtrlData.getFrameCTRLValue(encrypt, checksum, 0, require_ack, hasFrag)
-        byteOS.write(type.to_bytes(1, sys.byteorder))
+        byteOS.write(packet_type.to_bytes(1, sys.byteorder))
         byteOS.write(frameCtrl.to_bytes(1, sys.byteorder))
         byteOS.write(sequence.to_bytes(1, sys.byteorder))
         byteOS.write(dataLength.to_bytes(1, sys.byteorder))

--- a/tests/unit/bluetooth/test_ble_message.py
+++ b/tests/unit/bluetooth/test_ble_message.py
@@ -19,6 +19,14 @@ CUSTOM_DATA_TYPE = (19 << 2) | 1  # getTypeValue(1, 19) — pkgType=data, subTyp
 HEADER_LEN = 4
 
 
+def _inbound_frame(payload: bytes, sequence: int, *, fragmented: bool = False, checksum: bool = False) -> bytes:
+    """Build a raw inbound BluFi frame for parser recovery tests."""
+    frame_control = FrameCtrlData.getFrameCTRLValue(False, checksum, 1, False, fragmented)
+    data = len(payload).to_bytes(2, "little") + payload if fragmented else payload
+    frame = bytes([CUSTOM_DATA_TYPE, frame_control, sequence, len(data)]) + data
+    return frame + b"\x00\x00" if checksum else frame
+
+
 def _make_sender() -> tuple[BleMessage, list[bytes]]:
     """Build a BleMessage whose GATT writes are captured instead of sent."""
     client = MagicMock()
@@ -124,3 +132,36 @@ async def test_256_byte_payload_splits_into_two_frames() -> None:
     assert not FrameCtrlData(last[1]).hasFrag()
     assert last[3] == 256 - FRAG_CONTENT_LEN
     assert await _reassemble(frames) == payload
+
+
+async def test_sequence_gap_discards_partial_buffer_before_next_complete_frame() -> None:
+    """A lost fragment must not prefix stale bytes to the next report."""
+    receiver = BleMessage(MagicMock())
+
+    assert receiver.parseNotification(_inbound_frame(b"stale", 0, fragmented=True)) == 1
+    assert receiver.parseNotification(_inbound_frame(b"fresh", 2)) == 0
+
+    assert await receiver.parseBlufiNotifyData(return_bytes=True) == b"fresh"
+
+
+async def test_checksum_failure_discards_partial_buffer_and_recovers() -> None:
+    """A corrupt fragment must abandon the entire accumulated message."""
+    receiver = BleMessage(MagicMock())
+
+    assert receiver.parseNotification(_inbound_frame(b"stale", 0, fragmented=True)) == 1
+    assert receiver.parseNotification(_inbound_frame(b"corrupt", 1, checksum=True)) == -4
+    assert receiver.parseNotification(_inbound_frame(b"fresh", 2)) == 0
+
+    assert await receiver.parseBlufiNotifyData(return_bytes=True) == b"fresh"
+
+
+async def test_parse_exception_discards_partial_buffer_and_recovers() -> None:
+    """An exception while appending data must not poison the next frame."""
+    receiver = BleMessage(MagicMock())
+
+    assert receiver.parseNotification(_inbound_frame(b"stale", 0, fragmented=True)) == 1
+    receiver.notification.addData = MagicMock(side_effect=RuntimeError("append failed"))
+    assert receiver.parseNotification(_inbound_frame(b"corrupt", 1)) == -100
+    assert receiver.parseNotification(_inbound_frame(b"fresh", 2)) == 0
+
+    assert await receiver.parseBlufiNotifyData(return_bytes=True) == b"fresh"


### PR DESCRIPTION
## What changed
- clear accumulated receive fragments when a sequence gap is detected
- clear the same buffer after checksum rejection or a parser exception
- verify that the next complete frame contains only fresh bytes in all three cases
- clean pre-existing lint findings in the changed module without altering protocol behavior

## Why
`parseNotification()` detected frame loss and corruption but retained its append-only buffer. The next message was then delivered as `stale partial + fresh frame`, producing valid-looking protobuf data with fields spliced from a different report.

## Impact
Known-incomplete reports are discarded at the protocol boundary. The sequence counter still resynchronizes as before, and the current packet is parsed against a fresh buffer. Outbound payload framing at the 255-byte BluFi boundary is already fixed on `main` and is intentionally not duplicated here.

## Checks
- `python -m pytest tests/unit/bluetooth/test_ble_message.py -q` — 8 passed
- broader unit/integration selection — 1,043 passed
- Ruff 0.9.10 check and format check on `pymammotion/bluetooth/ble_message.py`
- `git diff --check`