### PR TITLE
correct path to map static files

### DIFF
--- a/pymammotion/data/model/generate_geojson.py
+++ b/pymammotion/data/model/generate_geojson.py
@@ -55,7 +55,7 @@ logger = logging.getLogger(__name__)
 GEOMETRY_TYPES: list[str] = ["Polygon", "Polygon", "LineString", "Point"]
 MAP_OBJECT_TYPES: list[str] = ["area", "path", "obstacle", "dump"]
 
-image_path = "/local/community/ha-mammotion-assets/dist/assets/map/"
+image_path = "/hacsfiles/ha-mammotion-assets/dist/assets/map/"
 
 RTK_IMAGE = {
     "iconImage": "map_icon_base_station_rtk.webp",


### PR DESCRIPTION
when installing this plugin on the latest home assistant version the path is incorrect for some of the static images for the map view.

```bash
> curl -o /dev/null -s -w "%{http_code}\n" \
  "http://homeassistant:8123/local/community/ha-mammotion-assets/dist/assets/map/map_icon_base_station_rtk.webp"
404
> curl -o /dev/null -s -w "%{http_code}\n" \
  "http://homeassistant:8123/hacsfiles/ha-mammotion-assets/dist/assets/map/map_icon_base_station_rtk.webp"
200
```